### PR TITLE
feat: WebSocket 연결 해제 시 퇴장 처리

### DIFF
--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/web/ReconnectGracePeriodManager.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/web/ReconnectGracePeriodManager.kt
@@ -1,0 +1,48 @@
+package ilpak.nomat.infrastructure.web
+
+import ilpak.nomat.room.application.RoomService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+@Component
+class ReconnectGracePeriodManager(
+    private val roomService: RoomService,
+    @Value("\${app.room.reconnect-grace-period-seconds:60}") private val gracePeriodSeconds: Long,
+) {
+
+    private val scheduler = Executors.newScheduledThreadPool(5)
+    private val pendingLeaves = ConcurrentHashMap<PendingLeaveKey, ScheduledFuture<*>>()
+
+    fun scheduleLeave(roomId: Long, playerId: Long) {
+        val key = PendingLeaveKey(roomId, playerId)
+        val future = scheduler.schedule(
+            {
+                pendingLeaves.remove(key)
+                roomService.leave(roomId, playerId)
+                log.info("유예 시간 만료로 퇴장 처리: roomId={}, playerId={}", roomId, playerId)
+            },
+            gracePeriodSeconds,
+            TimeUnit.SECONDS,
+        )
+        pendingLeaves[key] = future
+    }
+
+    fun cancelGracePeriod(roomId: Long, playerId: Long): Boolean {
+        val key = PendingLeaveKey(roomId, playerId)
+        val future = pendingLeaves.remove(key) ?: return false
+        future.cancel(false)
+        log.info("재접속으로 유예 취소: roomId={}, playerId={}", roomId, playerId)
+        return true
+    }
+
+    private data class PendingLeaveKey(val roomId: Long, val playerId: Long)
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ReconnectGracePeriodManager::class.java)
+    }
+}

--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/web/RoomJoinChannelInterceptor.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/web/RoomJoinChannelInterceptor.kt
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component
 @Component
 class RoomJoinChannelInterceptor(
     private val roomService: RoomService,
+    private val reconnectGracePeriodManager: ReconnectGracePeriodManager,
 ) : ChannelInterceptor {
 
     override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
@@ -26,11 +27,18 @@ class RoomJoinChannelInterceptor(
         val playerId = accessor.sessionAttributes?.get(JwtHandshakeInterceptor.PLAYER_ID_KEY) as? Long
             ?: throw BadRequestException("인증 정보가 없습니다.")
 
+        if (reconnectGracePeriodManager.cancelGracePeriod(roomId, playerId)) {
+            accessor.sessionAttributes?.set(ROOM_ID_KEY, roomId)
+            return message
+        }
+
         roomService.join(roomId, playerId, password)
+        accessor.sessionAttributes?.set(ROOM_ID_KEY, roomId)
         return message
     }
 
     companion object {
+        const val ROOM_ID_KEY = "roomId"
         private const val ROOM_ID_HEADER = "roomId"
         private const val PASSWORD_HEADER = "password"
     }

--- a/back/src/main/kotlin/ilpak/nomat/room/application/RoomService.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/RoomService.kt
@@ -111,4 +111,18 @@ class RoomService(
             }
         }
     }
+
+    fun leave(roomId: Long, playerId: Long) {
+        distributedLockExecutor.withLock("room:$roomId:lock") {
+            writeTransactionTemplate.executeWithoutResult {
+                val room = roomRepository.findById(roomId) ?: return@executeWithoutResult
+                room.leave(playerId)
+                if (room.isEmpty) {
+                    roomRepository.delete(room)
+                } else {
+                    roomRepository.save(room)
+                }
+            }
+        }
+    }
 }

--- a/back/src/main/kotlin/ilpak/nomat/room/application/domain/Room.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/domain/Room.kt
@@ -59,6 +59,9 @@ class Room(
     val playlistMasterId: Long
         get() = playlist.masterId
 
+    val isEmpty: Boolean
+        get() = entries.isEmpty()
+
     @Transient
     private var _sortedEntries: List<RoomEntry>? = null
     val sortedEntries: List<RoomEntry>
@@ -86,6 +89,15 @@ class Room(
         _sortedEntries = null
         status = RoomStatus.ACTIVE
         registerEvent(RoomJoinedEvent(id, playerId))
+    }
+
+    fun leave(playerId: Long) {
+        val removed = entries.removeIf { it.playerId == playerId }
+        if (!removed) {
+            return
+        }
+        _sortedEntries = null
+        registerEvent(RoomLeftEvent(id, playerId))
     }
 
     companion object {

--- a/back/src/main/kotlin/ilpak/nomat/room/application/domain/RoomLeftEvent.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/domain/RoomLeftEvent.kt
@@ -1,0 +1,6 @@
+package ilpak.nomat.room.application.domain
+
+data class RoomLeftEvent(
+    val roomId: Long,
+    val playerId: Long,
+)

--- a/back/src/main/kotlin/ilpak/nomat/room/application/domain/RoomRepository.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/domain/RoomRepository.kt
@@ -3,6 +3,7 @@ package ilpak.nomat.room.application.domain
 interface RoomRepository {
 
     fun save(room: Room): Room
+    fun delete(room: Room)
     fun findById(id: Long): Room?
     fun findByIdGreaterThanAndStatusOrderByIdDesc(id: Long, status: RoomStatus, size: Int): List<Room>
 }

--- a/back/src/main/kotlin/ilpak/nomat/room/application/dto/RoomEventMessage.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/dto/RoomEventMessage.kt
@@ -1,0 +1,15 @@
+package ilpak.nomat.room.application.dto
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = RoomJoinedEventMessage::class, name = "JOINED"),
+    JsonSubTypes.Type(value = RoomLeftEventMessage::class, name = "LEFT"),
+)
+interface RoomEventMessage {
+    val roomId: Long
+    val playerId: Long
+    val nickname: String
+}

--- a/back/src/main/kotlin/ilpak/nomat/room/application/dto/RoomLeftEventMessage.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/dto/RoomLeftEventMessage.kt
@@ -1,6 +1,6 @@
 package ilpak.nomat.room.application.dto
 
-data class RoomJoinedEventMessage(
+data class RoomLeftEventMessage(
     override val roomId: Long,
     override val playerId: Long,
     override val nickname: String,

--- a/back/src/main/kotlin/ilpak/nomat/room/in/RoomDisconnectListener.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/in/RoomDisconnectListener.kt
@@ -1,0 +1,23 @@
+package ilpak.nomat.room.`in`
+
+import ilpak.nomat.infrastructure.web.JwtHandshakeInterceptor
+import ilpak.nomat.infrastructure.web.ReconnectGracePeriodManager
+import ilpak.nomat.infrastructure.web.RoomJoinChannelInterceptor
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+@Component
+private class RoomDisconnectListener(
+    private val reconnectGracePeriodManager: ReconnectGracePeriodManager,
+) {
+
+    @EventListener
+    fun handleSessionDisconnect(event: SessionDisconnectEvent) {
+        val sessionAttributes = event.message.headers["simpSessionAttributes"] as? Map<*, *> ?: return
+        val playerId = sessionAttributes[JwtHandshakeInterceptor.PLAYER_ID_KEY] as? Long ?: return
+        val roomId = sessionAttributes[RoomJoinChannelInterceptor.ROOM_ID_KEY] as? Long ?: return
+
+        reconnectGracePeriodManager.scheduleLeave(roomId, playerId)
+    }
+}

--- a/back/src/main/kotlin/ilpak/nomat/room/in/RoomEventListener.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/in/RoomEventListener.kt
@@ -3,7 +3,9 @@ package ilpak.nomat.room.`in`
 import com.fasterxml.jackson.databind.ObjectMapper
 import ilpak.nomat.player.application.PlayerService
 import ilpak.nomat.room.application.domain.RoomJoinedEvent
+import ilpak.nomat.room.application.domain.RoomLeftEvent
 import ilpak.nomat.room.application.dto.RoomJoinedEventMessage
+import ilpak.nomat.room.application.dto.RoomLeftEventMessage
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -22,6 +24,20 @@ private class RoomEventListener(
         val channel = "room:${event.roomId}:events"
         val message = objectMapper.writeValueAsString(
             RoomJoinedEventMessage(
+                roomId = event.roomId,
+                playerId = event.playerId,
+                nickname = player.nickname,
+            )
+        )
+        redisTemplate.convertAndSend(channel, message)
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleRoomLeft(event: RoomLeftEvent) {
+        val player = playerService.findById(event.playerId)
+        val channel = "room:${event.roomId}:events"
+        val message = objectMapper.writeValueAsString(
+            RoomLeftEventMessage(
                 roomId = event.roomId,
                 playerId = event.playerId,
                 nickname = player.nickname,

--- a/back/src/main/kotlin/ilpak/nomat/room/in/RoomEventRedisSubscriber.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/in/RoomEventRedisSubscriber.kt
@@ -1,7 +1,8 @@
 package ilpak.nomat.room.`in`
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import ilpak.nomat.room.application.dto.RoomJoinedEventMessage
+import com.fasterxml.jackson.module.kotlin.readValue
+import ilpak.nomat.room.application.dto.RoomEventMessage
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.Message
@@ -19,7 +20,7 @@ private class RoomEventRedisSubscriber(
 ) : MessageListener {
 
     override fun onMessage(message: Message, pattern: ByteArray?) {
-        val event = objectMapper.readValue(message.body, RoomJoinedEventMessage::class.java)
+        val event = objectMapper.readValue<RoomEventMessage>(message.body)
         messagingTemplate.convertAndSend("/topic/rooms/${event.roomId}", event)
     }
 }

--- a/back/src/main/kotlin/ilpak/nomat/room/out/RoomRepositoryImpl.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/out/RoomRepositoryImpl.kt
@@ -17,6 +17,10 @@ private class RoomRepositoryImpl(
         return roomJpaRepository.save(room)
     }
 
+    override fun delete(room: Room) {
+        roomJpaRepository.delete(room)
+    }
+
     override fun findById(id: Long): Room? {
         return roomJpaRepository.findByIdOrNull(id)
     }

--- a/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/IntegrationTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/IntegrationTest.kt
@@ -19,7 +19,7 @@ import java.lang.annotation.Inherited
     classes = [NomatApplication::class, TestConfiguration::class],
     properties = ["spring.main.allow-bean-definition-overriding=true"],
 )
-@TestPropertySource(properties = ["spring.profiles.active=test"])
+@TestPropertySource(properties = ["spring.profiles.active=test", "app.room.reconnect-grace-period-seconds=2"])
 @EnableAutoConfiguration(exclude = [OAuth2ClientAutoConfiguration::class])
 @TestExecutionListeners(
     value = [IntegrationTestExecutionListener::class],

--- a/back/src/test/kotlin/ilpak/nomat/room/application/domain/RoomTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/room/application/domain/RoomTest.kt
@@ -171,4 +171,89 @@ class RoomTest {
         assertThatThrownBy { room.join(1) }
             .isExactlyInstanceOf(ConflictException::class.java)
     }
+
+    @Test
+    fun `leave_입장한 플레이어가 퇴장하면 entries에서 제거된다`() {
+        val room = Room(
+            title = "room",
+            playlist = RoomPlaylist(
+                id = 1,
+                masterId = 1,
+                title = "playlist",
+                description = "description",
+            ),
+            password = null,
+            maxEntriesCount = 5,
+        )
+        room.join(1)
+        room.join(2)
+
+        room.leave(1)
+
+        assertThat(room.playerIds).containsExactly(2L)
+    }
+
+    @Test
+    fun `leave_입장하지 않은 플레이어가 퇴장 시도하면 아무 일도 발생하지 않는다`() {
+        val room = Room(
+            title = "room",
+            playlist = RoomPlaylist(
+                id = 1,
+                masterId = 1,
+                title = "playlist",
+                description = "description",
+            ),
+            password = null,
+            maxEntriesCount = 5,
+        )
+        room.join(1)
+
+        room.leave(999)
+
+        assertThat(room.playerIds).containsExactly(1L)
+    }
+
+    @Test
+    fun `leave_퇴장 후 다시 입장할 수 있다`() {
+        val room = Room(
+            title = "room",
+            playlist = RoomPlaylist(
+                id = 1,
+                masterId = 1,
+                title = "playlist",
+                description = "description",
+            ),
+            password = null,
+            maxEntriesCount = 5,
+        )
+        room.join(1)
+        room.leave(1)
+
+        room.join(1)
+
+        assertThat(room.playerIds).containsExactly(1L)
+    }
+
+    @Test
+    fun `leave_모든 플레이어가 퇴장하면 방이 비어있다`() {
+        val room = Room(
+            title = "room",
+            playlist = RoomPlaylist(
+                id = 1,
+                masterId = 1,
+                title = "playlist",
+                description = "description",
+            ),
+            password = null,
+            maxEntriesCount = 5,
+        )
+        room.join(1)
+        room.join(2)
+
+        room.leave(1)
+        assertThat(room.isEmpty).isFalse()
+
+        room.leave(2)
+        assertThat(room.isEmpty).isTrue()
+    }
 }

--- a/back/src/test/kotlin/ilpak/nomat/room/application/in/RoomLeaveIntegrationTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/room/application/in/RoomLeaveIntegrationTest.kt
@@ -1,0 +1,202 @@
+package ilpak.nomat.room.application.`in`
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import ilpak.nomat.auth.application.TokenService
+import ilpak.nomat.infrastructure.integration.IntegrationTest
+import ilpak.nomat.infrastructure.integration.step.PlayerStep
+import ilpak.nomat.infrastructure.integration.step.PlaylistStep
+import ilpak.nomat.infrastructure.integration.step.RoomStep
+import ilpak.nomat.infrastructure.integration.step.dummyPlayerRequest
+import ilpak.nomat.infrastructure.integration.step.dummyPlaylistCreationRequest
+import ilpak.nomat.infrastructure.integration.step.dummyRoomRequest
+import ilpak.nomat.infrastructure.integration.util.auth
+import ilpak.nomat.player.application.dto.PlayerResponse
+import ilpak.nomat.playlist.application.dto.PlaylistWithTrackResponse
+import ilpak.nomat.room.application.dto.RoomDetailResponse
+import ilpak.nomat.room.application.dto.RoomEventMessage
+import ilpak.nomat.room.application.dto.RoomLeftEventMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.messaging.converter.MappingJackson2MessageConverter
+import org.springframework.messaging.simp.stomp.StompFrameHandler
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.web.socket.WebSocketHttpHeaders
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import java.lang.reflect.Type
+import java.time.Duration
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+@IntegrationTest
+class RoomLeaveIntegrationTest(
+    @Autowired private val client: WebTestClient,
+    @Autowired private val playerStep: PlayerStep,
+    @Autowired private val playlistStep: PlaylistStep,
+    @Autowired private val roomStep: RoomStep,
+    @Autowired private val tokenService: TokenService,
+    @Autowired private val objectMapper: ObjectMapper,
+    @LocalServerPort private val port: Int,
+) {
+
+    private lateinit var player: PlayerResponse
+    private lateinit var playlist: PlaylistWithTrackResponse
+
+    @BeforeEach
+    fun setUp() {
+        player = playerStep.save(dummyPlayerRequest())
+        playlist = playlistStep.save(player, dummyPlaylistCreationRequest())
+    }
+
+    @Test
+    fun `연결 해제 후 유예 시간 내 재접속하면 퇴장 처리되지 않는다`() {
+        val room = roomStep.save(player, dummyRoomRequest(playlist.id))
+        val joiner = playerStep.save(dummyPlayerRequest(nickname = "joiner", registrationId = "joinerId"))
+
+        val sessionA = connectStomp(player, room.id, "password")
+        val sessionB = connectStomp(joiner, room.id, "password")
+
+        val receivedEvents = LinkedBlockingQueue<RoomEventMessage>()
+        sessionA.subscribe("/topic/rooms/${room.id}", object : StompFrameHandler {
+            override fun getPayloadType(headers: StompHeaders): Type = RoomEventMessage::class.java
+            override fun handleFrame(headers: StompHeaders, payload: Any?) {
+                receivedEvents.add(payload as RoomEventMessage)
+            }
+        })
+
+        // 유저 B 연결 해제
+        sessionB.disconnect()
+        Thread.sleep(500)
+
+        // 유예 시간(2초) 내 재접속
+        val sessionB2 = connectStomp(joiner, room.id, "password")
+
+        // 유예 시간(2초)이 지나도 퇴장 이벤트가 발생하지 않아야 함
+        Thread.sleep(3000)
+        val leftEvents = receivedEvents.filter { it is RoomLeftEventMessage }
+        assertThat(leftEvents).isEmpty()
+
+        val detail = getRoomDetail(room.id)
+        assertThat(detail?.players).hasSize(2)
+        assertThat(detail?.players?.map { it.id }).contains(joiner.id)
+
+        sessionA.disconnect()
+        sessionB2.disconnect()
+    }
+
+    @Test
+    fun `연결 해제 후 유예 시간 경과 시 퇴장 메시지가 전달된다`() {
+        val room = roomStep.save(player, dummyRoomRequest(playlist.id))
+        val joiner = playerStep.save(dummyPlayerRequest(nickname = "joiner", registrationId = "joinerId"))
+
+        val sessionA = connectStomp(player, room.id, "password")
+        val sessionB = connectStomp(joiner, room.id, "password")
+
+        val receivedEvents = LinkedBlockingQueue<RoomEventMessage>()
+        sessionA.subscribe("/topic/rooms/${room.id}", object : StompFrameHandler {
+            override fun getPayloadType(headers: StompHeaders): Type = RoomEventMessage::class.java
+            override fun handleFrame(headers: StompHeaders, payload: Any?) {
+                receivedEvents.add(payload as RoomEventMessage)
+            }
+        })
+
+        // 유저 B 연결 해제 → 유예 시간(2초) 후 퇴장 처리
+        sessionB.disconnect()
+
+        await()
+            .pollInterval(Duration.ofMillis(500))
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted {
+                val leftEvents = receivedEvents.filter { it is RoomLeftEventMessage }
+                assertThat(leftEvents).hasSize(1)
+                val event = leftEvents.first()
+                assertThat(event.playerId).isEqualTo(joiner.id)
+                assertThat(event.nickname).isEqualTo("joiner")
+                assertThat(event.roomId).isEqualTo(room.id)
+            }
+
+        sessionA.disconnect()
+    }
+
+    @Test
+    fun `연결 해제 후 유예 시간 경과 시 방의 entries에서 해당 유저가 제거된다`() {
+        val room = roomStep.save(player, dummyRoomRequest(playlist.id))
+        val joiner = playerStep.save(dummyPlayerRequest(nickname = "joiner", registrationId = "joinerId"))
+
+        connectStomp(player, room.id, "password")
+        val sessionB = connectStomp(joiner, room.id, "password")
+
+        // 유저 B 연결 해제
+        sessionB.disconnect()
+
+        // 유예 시간(2초) 경과 후 entries에서 제거 확인
+        await()
+            .pollInterval(Duration.ofMillis(500))
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted {
+                val detail = getRoomDetail(room.id)
+                assertThat(detail?.players?.map { it.id }).doesNotContain(joiner.id)
+            }
+    }
+
+    @Test
+    fun `모든 유저가 퇴장하면 방이 삭제된다`() {
+        val room = roomStep.save(player, dummyRoomRequest(playlist.id))
+
+        val sessionA = connectStomp(player, room.id, "password")
+
+        // 유일한 유저가 연결 해제
+        sessionA.disconnect()
+
+        // 유예 시간(2초) 경과 후 방 삭제 확인
+        await()
+            .pollInterval(Duration.ofMillis(500))
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted {
+                client.get().uri("/rooms/{roomId}", room.id)
+                    .auth(player)
+                    .exchange()
+                    .expectStatus().isNotFound()
+            }
+    }
+
+    private fun getRoomDetail(roomId: Long): RoomDetailResponse? {
+        return client.get().uri("/rooms/{roomId}", roomId)
+            .auth(player)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody<RoomDetailResponse>()
+            .returnResult()
+            .responseBody
+    }
+
+    private fun connectStomp(player: PlayerResponse, roomId: Long, password: String?): StompSession {
+        val stompClient = WebSocketStompClient(StandardWebSocketClient())
+        stompClient.messageConverter = MappingJackson2MessageConverter(objectMapper)
+
+        val stompHeaders = StompHeaders()
+        stompHeaders.add("roomId", roomId.toString())
+        if (password != null) {
+            stompHeaders.add("password", password)
+        }
+
+        val httpHeaders = WebSocketHttpHeaders()
+        val token = tokenService.getNewToken(player.id)
+        httpHeaders.add("Cookie", "${TokenService.TOKEN_COOKIE_KEY}=$token")
+
+        return stompClient.connectAsync(
+            "ws://localhost:$port/ws",
+            httpHeaders,
+            stompHeaders,
+            object : StompSessionHandlerAdapter() {}
+        ).get(5, TimeUnit.SECONDS)
+    }
+}


### PR DESCRIPTION
## Summary
- WebSocket 세션 종료 시 1분 재접속 유예 시간을 부여하고, 미접속 시 퇴장 처리
- 퇴장 이벤트를 Redis Pub/Sub으로 남은 유저에게 브로드캐스트
- 모든 유저가 퇴장하면 방 자동 삭제

Closes #117

## Test plan
- [x] 연결 해제 후 유예 시간 내 재접속 시 퇴장 처리되지 않는지 확인
- [x] 연결 해제 후 유예 시간 경과 시 퇴장 메시지가 전달되는지 확인
- [x] 연결 해제 후 유예 시간 경과 시 방의 entries에서 해당 유저가 제거되는지 확인
- [x] 모든 유저가 퇴장하면 방이 삭제되는지 확인
- [x] Room 도메인 leave 단위 테스트 (퇴장, 미입장 유저 퇴장, 퇴장 후 재입장, isEmpty)
- [x] 기존 입장 관련 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)