### PR TITLE
feat: 네온/게이밍 디자인 시스템 토큰 및 유틸리티 정의

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -3,11 +3,76 @@
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+
+  /* Background */
+  --color-background: #0a0a0f;
+  --color-surface: #0f0f14;
+  --color-card: #18181b;
+  --color-border: #27272a;
+  --color-muted: #3f3f46;
+
+  /* Neon Accent */
+  --color-neon-cyan: #22d3ee;
+  --color-neon-purple: #a78bfa;
+  --color-neon-pink: #f472b6;
+  --color-neon-green: #34d399;
+
+  /* Semantic */
+  --color-secondary: #22d3ee;
+  --color-success: #34d399;
+  --color-error: #f87171;
+  --color-warning: #fbbf24;
+  --color-info: #22d3ee;
+}
+
+/* Glow — 기본 */
+@utility shadow-glow-cyan {
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.15), inset 0 0 20px rgba(34, 211, 238, 0.05);
+}
+@utility shadow-glow-purple {
+  box-shadow: 0 0 20px rgba(167, 139, 250, 0.15), inset 0 0 20px rgba(167, 139, 250, 0.05);
+}
+@utility shadow-glow-pink {
+  box-shadow: 0 0 20px rgba(244, 114, 182, 0.15), inset 0 0 20px rgba(244, 114, 182, 0.05);
+}
+@utility shadow-glow-green {
+  box-shadow: 0 0 20px rgba(52, 211, 153, 0.15), inset 0 0 20px rgba(52, 211, 153, 0.05);
+}
+
+/* Glow — 강한 버전 (호버 상태) */
+@utility shadow-glow-cyan-lg {
+  box-shadow: 0 0 40px rgba(34, 211, 238, 0.3), inset 0 0 30px rgba(34, 211, 238, 0.1);
+}
+@utility shadow-glow-purple-lg {
+  box-shadow: 0 0 40px rgba(167, 139, 250, 0.3), inset 0 0 30px rgba(167, 139, 250, 0.1);
+}
+@utility shadow-glow-pink-lg {
+  box-shadow: 0 0 40px rgba(244, 114, 182, 0.3), inset 0 0 30px rgba(244, 114, 182, 0.1);
+}
+@utility shadow-glow-green-lg {
+  box-shadow: 0 0 40px rgba(52, 211, 153, 0.3), inset 0 0 30px rgba(52, 211, 153, 0.1);
+}
+
+/* 그라디언트 배경 */
+@utility bg-gradient-dark {
+  background: linear-gradient(145deg, #18181b, #1a1a22);
+}
+@utility bg-gradient-mesh {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(34, 211, 238, 0.08), transparent 50%),
+    radial-gradient(circle at 80% 80%, rgba(167, 139, 250, 0.06), transparent 50%),
+    #0a0a0f;
+}
+@utility bg-gradient-neon-cyan {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.1), rgba(34, 211, 238, 0.05));
+}
+@utility bg-gradient-neon-purple {
+  background: linear-gradient(135deg, rgba(167, 139, 250, 0.1), rgba(167, 139, 250, 0.05));
 }
 
 html,
 body {
-  @apply bg-zinc-900;
+  @apply bg-background;
   @apply text-zinc-50;
   @apply w-full;
   @apply h-full;
@@ -23,14 +88,14 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: transparent; /* 스크롤 트랙(배경) 투명 */
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #888; /* 스크롤바 색상 */
+  background: var(--color-muted);
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background: var(--color-border);
 }


### PR DESCRIPTION
## Summary
- `@theme` 블록에 시맨틱 컬러 토큰 14종 추가 (Background 5종, Neon Accent 4종, Semantic 5종)
- `@utility`로 글로우 shadow 8개 (4색 × 기본/lg) 및 그라디언트 배경 4종 정의
- `html, body` 배경 `bg-zinc-900` → `bg-background`(`#0a0a0f`) 변경
- 스크롤바 하드코딩 색상을 토큰 기반(`var(--color-muted)`, `var(--color-border)`)으로 변경

Closes #130

## Test plan
- [x] `npm run build` 성공 확인
- [x] 기존 페이지(`bg-zinc-*`, `text-zinc-*` 등) 정상 렌더링 확인
- [x] 새 유틸리티 클래스 사용 가능 확인 (`bg-background`, `text-neon-cyan`, `shadow-glow-cyan` 등)
- [x] `ui-preview.html` 색상값과 토큰 값 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)