### PR TITLE
feat: 반응형 훅 및 컬럼 레이아웃 반응형 대응

### DIFF
--- a/front/app/components/layout/Column1.tsx
+++ b/front/app/components/layout/Column1.tsx
@@ -4,7 +4,7 @@ interface NavigationContent extends React.PropsWithChildren {}
 
 const Column1: React.FC<NavigationContent> = ({children}) => {
      return <div
-     className="flex-1 flex flex-col px-1 gap-4 max-w-180"
+     className="w-full md:flex-1 flex flex-col px-1 gap-4 md:max-w-180"
     >
         {children}
     </div>

--- a/front/app/components/layout/Column2.tsx
+++ b/front/app/components/layout/Column2.tsx
@@ -2,7 +2,7 @@ interface NavigationContent extends React.PropsWithChildren {}
 
 const Column2: React.FC<NavigationContent> = ({children}) => {
      return <div
-     className="flex-2 flex flex-col px-1 gap-4"
+     className="w-full md:flex-2 flex flex-col px-1 gap-4"
     >
         {children}
     </div>

--- a/front/app/components/layout/ColumnsContainer.tsx
+++ b/front/app/components/layout/ColumnsContainer.tsx
@@ -2,7 +2,7 @@ interface NavigationContent extends React.PropsWithChildren {}
 
 const ColumnsContainer: React.FC<NavigationContent> = ({children}) => {
      return <div
-     className="w-full flex flex-row flex-nowrap overflow-auto"
+     className="w-full flex flex-col md:flex-row md:flex-nowrap overflow-auto"
     >
         {children}
     </div>

--- a/front/app/hooks/useBreakpoint.ts
+++ b/front/app/hooks/useBreakpoint.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+interface Breakpoint {
+    isMobile: boolean;
+    isTablet: boolean;
+    isDesktop: boolean;
+}
+
+const MOBILE_QUERY = "(max-width: 767px)";
+const TABLET_QUERY = "(min-width: 768px) and (max-width: 1023px)";
+const DESKTOP_QUERY = "(min-width: 1024px)";
+
+export default function useBreakpoint(): Breakpoint {
+    const [breakpoint, setBreakpoint] = useState<Breakpoint>(() => ({
+        isMobile: window.matchMedia(MOBILE_QUERY).matches,
+        isTablet: window.matchMedia(TABLET_QUERY).matches,
+        isDesktop: window.matchMedia(DESKTOP_QUERY).matches,
+    }));
+
+    useEffect(() => {
+        const mobileQuery = window.matchMedia(MOBILE_QUERY);
+        const tabletQuery = window.matchMedia(TABLET_QUERY);
+        const desktopQuery = window.matchMedia(DESKTOP_QUERY);
+
+        function update() {
+            setBreakpoint({
+                isMobile: mobileQuery.matches,
+                isTablet: tabletQuery.matches,
+                isDesktop: desktopQuery.matches,
+            });
+        }
+
+        mobileQuery.addEventListener("change", update);
+        tabletQuery.addEventListener("change", update);
+        desktopQuery.addEventListener("change", update);
+
+        return () => {
+            mobileQuery.removeEventListener("change", update);
+            tabletQuery.removeEventListener("change", update);
+            desktopQuery.removeEventListener("change", update);
+        };
+    }, []);
+
+    return breakpoint;
+}


### PR DESCRIPTION
## Summary
- `useBreakpoint` 훅 생성: `window.matchMedia` 기반 mobile/tablet/desktop 브레이크포인트 감지
- `ColumnsContainer`: 모바일(`< 768px`)에서 `flex-col` 세로 스택, `md` 이상에서 기존 `flex-row` 유지
- `Column1`: 모바일에서 `w-full`, `md` 이상에서 `flex-1` + `max-w-180` 유지
- `Column2`: 모바일에서 `w-full`, `md` 이상에서 `flex-2` 유지

Closes #133

## Test plan
- [x] 768px 미만에서 Column1, Column2가 세로로 스택되는지 확인
- [x] 768px 이상에서 기존 가로 배치(1:2 비율)가 유지되는지 확인
- [x] 브라우저 리사이즈 시 레이아웃이 즉시 전환되는지 확인
- [x] 320px ~ 1920px 범위에서 레이아웃이 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)