### PR TITLE
feat: 네비게이션 및 프로필 컴포넌트 개선

### DIFF
--- a/front/app/components/layout/NavigationBar.tsx
+++ b/front/app/components/layout/NavigationBar.tsx
@@ -2,7 +2,7 @@ interface NavigationContent extends React.PropsWithChildren {}
 
 const NavigationBar: React.FC<NavigationContent> = ({children}) => {
      return <div
-     className="h-full w-[112px] px-[8px] py-[16px] flex flex-col items-center"
+     className="h-full w-[72px] py-[16px] hidden md:flex flex-col items-center gap-[8px]"
     >
         {children}
     </div>

--- a/front/app/components/layout/NavigationItem.tsx
+++ b/front/app/components/layout/NavigationItem.tsx
@@ -14,11 +14,21 @@ export default function NavigationItem({
     clicked = false,
     onClick = () => {},
 }: NavigationItemProperties) {
-    return <div onClick={onClick} className={`w-[96px] flex flex-col items-center ${clicked ? "text-zinc-600" : "cursor-pointer"}`}>
+    return <div
+        onClick={onClick}
+        title={title as string}
+        className={`relative w-[48px] h-[48px] flex items-center justify-center rounded-lg transition-all duration-200 ${
+            clicked
+                ? "bg-[rgba(34,211,238,0.1)] shadow-glow-cyan"
+                : "cursor-pointer hover:bg-zinc-800/50"
+        }`}
+    >
+        {clicked && (
+            <span className="absolute left-0 top-[12px] w-[2px] h-[24px] rounded-r-sm bg-neon-cyan shadow-[0_0_10px_#22d3ee]" />
+        )}
         {React.isValidElement<{ className?: string }>(icon) &&
         React.cloneElement(icon, {
-          className: `size-[56px] ${clicked ? "fill-zinc-600" : ""}`,
+            className: `size-[24px] ${clicked ? "fill-neon-cyan text-neon-cyan drop-shadow-[0_0_8px_rgba(34,211,238,0.5)]" : ""}`,
         })}
-        <p>{title}</p>
     </div>
 }

--- a/front/app/components/ui/Me.tsx
+++ b/front/app/components/ui/Me.tsx
@@ -5,7 +5,11 @@ import MeStore from "~/stores/MeStore";
 import { fetchMe } from "~/utils/api";
 import { getRegistrationCode } from "~/utils/registrationCode";
 
-export default function Me() {
+interface MeProperties {
+    compact?: boolean;
+}
+
+export default function Me({ compact = false }: MeProperties) {
     const meStore = MeStore()
     if (!meStore.me) {
         fetchMe()
@@ -17,7 +21,7 @@ export default function Me() {
     const me = meStore.me
 
     const nicknameRef = useRef<HTMLDivElement>(null);
-    const defaultWidth = 80;
+    const defaultWidth = 56;
     const [width, setWidth] = useState(defaultWidth);
     const [isHover, setHover] = useState(false);
 
@@ -35,19 +39,27 @@ export default function Me() {
         setWidth(nicknameRefCurrent.clientWidth + defaultWidth);
     }, [isHover]);
 
+    if (compact) {
+        return (
+            <div className="size-[32px] flex items-center justify-center rounded-full bg-zinc-800">
+                <UserIcon className="size-[20px]" />
+            </div>
+        );
+    }
+
     return <>
-        <div className="me size-[96px] p-[8px]">
+        <div className="me size-[72px] p-[8px]">
             <div
-                className={`h-[80px] flex flex-row items-center align-middle profile transition-all transform rounded-full ${isHover ? "drop-shadow-lg" : ""}`}
+                className={`h-[56px] flex flex-row items-center align-middle profile transition-all transform rounded-full ${isHover ? "drop-shadow-lg" : ""}`}
                 onMouseEnter={ () => setHover(true) }
                 onMouseLeave={ () => setHover(false) }
                 style={{ width: `${width}px` }}
             >
-                <div className={`grow-0 shrink-0 w-[80px] h-[80px] p-[12px] flex`}>
-                    <UserIcon className="size-[56px] m-auto"></UserIcon>
+                <div className={`grow-0 shrink-0 w-[56px] h-[56px] p-[8px] flex`}>
+                    <UserIcon className="size-[40px] m-auto"></UserIcon>
                 </div>
-                <div ref={nicknameRef} className={`grow-0 shrink-0 pr-[36px] my-auto text-4xl align-top nickname`}>
-                    <p>{me?.nickname}<span className="text-xl ml-2 text-zinc-400">#{getRegistrationCode(me?.registrationType)}</span></p>
+                <div ref={nicknameRef} className={`grow-0 shrink-0 pr-[36px] my-auto text-3xl align-top nickname`}>
+                    <p>{me?.nickname}<span className="text-lg ml-2 text-zinc-400">#{getRegistrationCode(me?.registrationType)}</span></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- NavigationBar를 72px 컴팩트 모드로 변경하고, 모바일(`<768px`)에서 `hidden md:flex`로 숨김
- NavigationItem 활성 상태에 네온 글로우 적용 (좌측 cyan 바 + 배경 + 아이콘 글로우)
- Me 컴포넌트에 `compact` prop 추가 (32px 아바타 전용 모드)
- 기본 Me 모드를 72px 사이드바에 맞게 축소 (96px → 72px)

Closes #134

## Test plan
- [ ] 데스크톱(≥768px)에서 사이드바가 72px로 렌더링되는지 확인
- [ ] 768px 미만에서 사이드바가 숨겨지는지 확인
- [ ] NavigationItem 활성 상태에서 좌측 cyan 바 + 배경 글로우가 표시되는지 확인
- [ ] `<Me compact />` 렌더링 시 32px 아바타만 표시되는지 확인
- [ ] 기본 Me 컴포넌트의 호버 확장이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)