### PR TITLE
feat: CSS 애니메이션 유틸리티 및 Button 공통 컴포넌트 추가

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -53,6 +53,37 @@
   box-shadow: 0 0 40px rgba(52, 211, 153, 0.3), inset 0 0 30px rgba(52, 211, 153, 0.1);
 }
 
+/* 애니메이션 */
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+@keyframes slide-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@utility animate-fade-in {
+  animation: fade-in 0.2s ease-out;
+}
+@utility animate-fade-out {
+  animation: fade-out 0.2s ease-out;
+}
+@utility animate-scale-in {
+  animation: scale-in 0.2s ease-out;
+}
+@utility animate-slide-down {
+  animation: slide-down 0.2s ease-out;
+}
+
 /* 그라디언트 배경 */
 @utility bg-gradient-dark {
   background: linear-gradient(145deg, #18181b, #1a1a22);

--- a/front/app/components/ui/Button.tsx
+++ b/front/app/components/ui/Button.tsx
@@ -1,0 +1,62 @@
+import { type ButtonHTMLAttributes } from "react";
+
+type Variant = "primary" | "secondary" | "ghost" | "danger";
+type Size = "sm" | "md" | "lg";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: Variant;
+    size?: Size;
+    loading?: boolean;
+    fullWidth?: boolean;
+}
+
+const variantStyles: Record<Variant, string> = {
+    primary:
+        "bg-cyan-500/20 text-cyan-400 border border-cyan-500/30 shadow-glow-cyan hover:bg-cyan-500/30 hover:shadow-glow-cyan-lg",
+    secondary:
+        "bg-transparent text-zinc-300 border border-zinc-600 hover:border-zinc-400 hover:text-zinc-100",
+    ghost:
+        "bg-transparent text-zinc-400 border border-transparent hover:bg-zinc-800 hover:text-zinc-200",
+    danger:
+        "bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30",
+};
+
+const sizeStyles: Record<Size, string> = {
+    sm: "px-3 py-1.5 text-xs rounded-lg",
+    md: "px-4 py-2 text-sm rounded-xl",
+    lg: "px-6 py-3 text-base rounded-xl",
+};
+
+export default function Button({
+    variant = "primary",
+    size = "md",
+    loading = false,
+    fullWidth = false,
+    disabled,
+    className = "",
+    children,
+    ...rest
+}: ButtonProps) {
+    const isDisabled = disabled || loading;
+
+    return (
+        <button
+            disabled={isDisabled}
+            className={`
+                inline-flex items-center justify-center font-medium
+                transition-all duration-200 cursor-pointer
+                ${variantStyles[variant]}
+                ${sizeStyles[size]}
+                ${fullWidth ? "w-full" : ""}
+                ${isDisabled ? "opacity-50 cursor-not-allowed pointer-events-none" : ""}
+                ${className}
+            `}
+            {...rest}
+        >
+            {loading && (
+                <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
+            {children}
+        </button>
+    );
+}


### PR DESCRIPTION
## Summary
- `app.css`에 `fade-in`, `fade-out`, `scale-in`, `slide-down` 키프레임 및 `@utility` 애니메이션 클래스 추가
- `Button` 공통 컴포넌트 신규 생성: 4가지 변형(primary, secondary, ghost, danger), 3가지 사이즈(sm, md, lg), loading/disabled/fullWidth 상태 지원

Closes #138

## Test plan
- [ ] `animate-fade-in`, `animate-scale-in`, `animate-slide-down` 클래스가 Tailwind에서 정상 동작 확인
- [ ] Button 컴포넌트 4가지 변형 렌더링 확인
- [ ] Button loading 상태에서 스피너 표시 및 pointer-events-none 확인
- [ ] Button disabled 상태에서 opacity-50 및 클릭 불가 확인
- [ ] Button fullWidth prop으로 w-full 토글 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)