### PR TITLE
feat: AppShell 및 모바일 전용 컴포넌트 구현 (#135)

### DIFF
--- a/front/app/components/layout/AppShell.tsx
+++ b/front/app/components/layout/AppShell.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import useBreakpoint from "~/hooks/useBreakpoint";
+import NavigationBar from "~/components/layout/NavigationBar";
+import NavigationItem from "~/components/layout/NavigationItem";
+import MobileHeader from "~/components/layout/MobileHeader";
+import MobileBottomNav from "~/components/layout/MobileBottomNav";
+import Me from "~/components/ui/Me";
+import RoomIcon from "~/assets/room.svg?react";
+import PlaylistIcon from "~/assets/playlist.svg?react";
+import BackIcon from "~/assets/back.svg?react";
+
+interface AppShellMainProps {
+    variant: "main";
+    activeTab: "rooms" | "playlists";
+    title: string;
+    children: ReactNode;
+}
+
+interface AppShellSubProps {
+    variant: "sub";
+    title: string;
+    backTo?: string;
+    onBack?: () => void;
+    actions?: { icon: ReactNode; label: string; onClick: () => void }[];
+    children: ReactNode;
+}
+
+type AppShellProps = AppShellMainProps | AppShellSubProps;
+
+export default function AppShell(props: AppShellProps) {
+    const { isMobile } = useBreakpoint();
+
+    if (props.variant === "main") {
+        return <MainShell {...props} isMobile={isMobile} />;
+    }
+
+    return <SubShell {...props} isMobile={isMobile} />;
+}
+
+function MainShell({
+    activeTab,
+    title,
+    children,
+    isMobile,
+}: AppShellMainProps & { isMobile: boolean }) {
+    return (
+        <div className="flex flex-row w-full h-full">
+            <NavigationBar>
+                <div className="grow shrink flex flex-col gap-4">
+                    <Link to="/" replace>
+                        <NavigationItem
+                            clicked={activeTab === "rooms"}
+                            icon={<RoomIcon />}
+                            title="플레이 룸"
+                        />
+                    </Link>
+                    <Link to="/playlists" replace>
+                        <NavigationItem
+                            clicked={activeTab === "playlists"}
+                            icon={<PlaylistIcon />}
+                            title="플레이리스트"
+                        />
+                    </Link>
+                </div>
+                <div className="grow-0 shrink-0">
+                    <Me />
+                </div>
+            </NavigationBar>
+
+            {isMobile ? (
+                <div className="flex-1 flex flex-col h-full min-h-0">
+                    <MobileHeader variant="main" title={title} />
+                    <div className="flex-1 overflow-auto">{children}</div>
+                    <MobileBottomNav activeTab={activeTab} />
+                </div>
+            ) : (
+                children
+            )}
+        </div>
+    );
+}
+
+function SubShell({
+    title,
+    backTo,
+    onBack,
+    actions = [],
+    children,
+    isMobile,
+}: AppShellSubProps & { isMobile: boolean }) {
+    return (
+        <div className="flex flex-row w-full h-full">
+            <NavigationBar>
+                <div className="grow shrink flex flex-col gap-4">
+                    {backTo ? (
+                        <Link to={backTo} replace>
+                            <NavigationItem icon={<BackIcon />} title="뒤로가기" />
+                        </Link>
+                    ) : onBack ? (
+                        <NavigationItem
+                            icon={<BackIcon />}
+                            title="뒤로가기"
+                            onClick={onBack}
+                        />
+                    ) : null}
+                    {actions.map((action, index) => (
+                        <NavigationItem
+                            key={index}
+                            icon={action.icon}
+                            title={action.label}
+                            onClick={action.onClick}
+                        />
+                    ))}
+                </div>
+                <div className="grow-0 shrink-0">
+                    <Me />
+                </div>
+            </NavigationBar>
+
+            {isMobile ? (
+                <div className="flex-1 flex flex-col h-full min-h-0">
+                    <MobileHeader
+                        variant="sub"
+                        title={title}
+                        backTo={backTo}
+                        onBack={onBack}
+                        actions={actions}
+                    />
+                    <div className="flex-1 overflow-auto">{children}</div>
+                </div>
+            ) : (
+                children
+            )}
+        </div>
+    );
+}

--- a/front/app/components/layout/MobileBottomNav.tsx
+++ b/front/app/components/layout/MobileBottomNav.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import React from "react";
+import RoomIcon from "~/assets/room.svg?react";
+import PlaylistIcon from "~/assets/playlist.svg?react";
+import UserIcon from "~/assets/user.svg?react";
+import MeStore from "~/stores/MeStore";
+import { getRegistrationCode } from "~/utils/registrationCode";
+
+interface MobileBottomNavProps {
+    activeTab: "rooms" | "playlists";
+}
+
+export default function MobileBottomNav({ activeTab }: MobileBottomNavProps) {
+    const [showProfile, setShowProfile] = useState(false);
+    const meStore = MeStore();
+    const me = meStore.me;
+
+    const tabs = [
+        { key: "rooms" as const, to: "/", icon: <RoomIcon />, label: "플레이 룸" },
+        { key: "playlists" as const, to: "/playlists", icon: <PlaylistIcon />, label: "플레이리스트" },
+    ];
+
+    return (
+        <nav className="shrink-0 h-[64px] relative bg-surface/80 backdrop-blur-[16px]">
+            {showProfile && me && (
+                <div className="absolute bottom-[68px] right-2 w-48 p-3 rounded-xl bg-zinc-800 border border-border shadow-lg">
+                    <div className="flex items-center gap-2">
+                        <div className="size-[32px] flex items-center justify-center rounded-full bg-zinc-700">
+                            <UserIcon className="size-[20px]" />
+                        </div>
+                        <div className="flex flex-col min-w-0">
+                            <p className="text-sm font-bold truncate">{me.nickname}</p>
+                            <p className="text-xs text-zinc-400">#{getRegistrationCode(me.registrationType)}</p>
+                        </div>
+                    </div>
+                </div>
+            )}
+            <div className="h-full flex items-center justify-around px-4">
+                {tabs.map((tab) => {
+                    const isActive = activeTab === tab.key;
+                    return (
+                        <Link
+                            key={tab.key}
+                            to={tab.to}
+                            replace
+                            className={`flex flex-col items-center justify-center gap-1 px-4 py-2 rounded-xl transition-all duration-200 ${
+                                isActive
+                                    ? "bg-[rgba(34,211,238,0.1)]"
+                                    : ""
+                            }`}
+                        >
+                            {React.isValidElement<{ className?: string }>(tab.icon) &&
+                                React.cloneElement(tab.icon, {
+                                    className: `size-[24px] ${
+                                        isActive
+                                            ? "fill-neon-cyan text-neon-cyan drop-shadow-[0_0_8px_rgba(34,211,238,0.5)]"
+                                            : ""
+                                    }`,
+                                })}
+                            <span className={`text-xs ${isActive ? "text-neon-cyan" : "text-zinc-400"}`}>
+                                {tab.label}
+                            </span>
+                        </Link>
+                    );
+                })}
+                <button
+                    onClick={() => setShowProfile(!showProfile)}
+                    className={`flex flex-col items-center justify-center gap-1 px-4 py-2 rounded-xl transition-all duration-200 ${
+                        showProfile ? "bg-[rgba(34,211,238,0.1)]" : ""
+                    }`}
+                >
+                    <UserIcon
+                        className={`size-[24px] ${
+                            showProfile
+                                ? "fill-neon-cyan text-neon-cyan drop-shadow-[0_0_8px_rgba(34,211,238,0.5)]"
+                                : ""
+                        }`}
+                    />
+                    <span className={`text-xs ${showProfile ? "text-neon-cyan" : "text-zinc-400"}`}>
+                        프로필
+                    </span>
+                </button>
+            </div>
+        </nav>
+    );
+}

--- a/front/app/components/layout/MobileHeader.tsx
+++ b/front/app/components/layout/MobileHeader.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import React from "react";
+import { Link } from "react-router";
+import BackArrowIcon from "~/assets/back-arrow.svg?react";
+import Me from "~/components/ui/Me";
+
+interface MobileHeaderMainProps {
+    variant: "main";
+    title: string;
+}
+
+interface MobileHeaderSubProps {
+    variant: "sub";
+    title: string;
+    backTo?: string;
+    onBack?: () => void;
+    actions?: { icon: ReactNode; label: string; onClick: () => void }[];
+}
+
+type MobileHeaderProps = MobileHeaderMainProps | MobileHeaderSubProps;
+
+export default function MobileHeader(props: MobileHeaderProps) {
+    if (props.variant === "main") {
+        return (
+            <header className="shrink-0 h-[56px] px-4 flex items-center justify-between bg-surface/80 backdrop-blur-[16px]">
+                <h1 className="text-lg font-bold">{props.title}</h1>
+                <Me compact />
+            </header>
+        );
+    }
+
+    const { title, backTo, onBack, actions = [] } = props;
+
+    const backButton = (
+        <button
+            onClick={onBack}
+            className="size-[40px] flex items-center justify-center rounded-lg hover:bg-zinc-800/50 transition-colors"
+        >
+            <BackArrowIcon className="size-[24px]" />
+        </button>
+    );
+
+    return (
+        <header className="shrink-0 h-[56px] px-2 flex items-center bg-surface/80 backdrop-blur-[16px]">
+            <div className="shrink-0">
+                {backTo ? (
+                    <Link to={backTo} replace>
+                        {backButton}
+                    </Link>
+                ) : (
+                    backButton
+                )}
+            </div>
+            <h1 className="flex-1 text-center text-lg font-bold truncate px-2">
+                {title}
+            </h1>
+            <div className="shrink-0 flex items-center gap-1">
+                {actions.map((action, index) => (
+                    <button
+                        key={index}
+                        onClick={action.onClick}
+                        title={action.label}
+                        className="size-[40px] flex items-center justify-center rounded-lg hover:bg-zinc-800/50 transition-colors"
+                    >
+                        {React.isValidElement<{ className?: string }>(action.icon) &&
+                            React.cloneElement(action.icon, {
+                                className: "size-[24px]",
+                            })}
+                    </button>
+                ))}
+            </div>
+        </header>
+    );
+}


### PR DESCRIPTION
## Summary
- `MobileHeader` 컴포넌트: main variant(페이지 제목 + 소형 아바타), sub variant(뒤로가기 + 제목 + 액션 버튼)
- `MobileBottomNav` 컴포넌트: 플레이 룸 / 플레이리스트 / 프로필 3탭, 활성 탭 네온 글로우, 프로필 팝오버
- `AppShell` 레이아웃 셸: `useBreakpoint` 훅으로 데스크톱(사이드바+콘텐츠) / 모바일(헤더+콘텐츠+하단바) 분기 처리

Closes #135

## Test plan
- [ ] `<AppShell variant="main" activeTab="rooms" title="플레이 룸">` 데스크톱에서 72px 사이드바 + 콘텐츠 표시
- [ ] 768px 미만에서 사이드바 숨김, MobileHeader + MobileBottomNav 표시
- [ ] `<AppShell variant="sub" title="방 제목" backTo="/">` 모바일에서 ← 뒤로가기 + 제목 + 액션 버튼 표시
- [ ] 모바일 하단 네비게이션에서 플레이 룸 / 플레이리스트 탭 전환 동작
- [ ] 프로필 탭 클릭 시 사용자 정보 팝오버 표시/숨김

🤖 Generated with [Claude Code](https://claude.com/claude-code)