### PR TITLE
feat: 라우트 뷰 AppShell 전환 (#136)

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -116,6 +116,7 @@ body {
 
 ::-webkit-scrollbar {
   width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {

--- a/front/app/components/layout/NavigationItem.tsx
+++ b/front/app/components/layout/NavigationItem.tsx
@@ -16,19 +16,21 @@ export default function NavigationItem({
 }: NavigationItemProperties) {
     return <div
         onClick={onClick}
-        title={title as string}
-        className={`relative w-[48px] h-[48px] flex items-center justify-center rounded-lg transition-all duration-200 ${
+        className={`relative w-[56px] flex flex-col items-center justify-center gap-1 py-2 rounded-lg transition-all duration-200 ${
             clicked
                 ? "bg-[rgba(34,211,238,0.1)] shadow-glow-cyan"
                 : "cursor-pointer hover:bg-zinc-800/50"
         }`}
     >
         {clicked && (
-            <span className="absolute left-0 top-[12px] w-[2px] h-[24px] rounded-r-sm bg-neon-cyan shadow-[0_0_10px_#22d3ee]" />
+            <span className="absolute left-0 top-[10px] w-[2px] h-[24px] rounded-r-sm bg-neon-cyan shadow-[0_0_10px_#22d3ee]" />
         )}
         {React.isValidElement<{ className?: string }>(icon) &&
         React.cloneElement(icon, {
             className: `size-[24px] ${clicked ? "fill-neon-cyan text-neon-cyan drop-shadow-[0_0_8px_rgba(34,211,238,0.5)]" : ""}`,
         })}
+        <span className={`text-[10px] leading-tight ${clicked ? "text-neon-cyan" : "text-zinc-400"}`}>
+            {title as string}
+        </span>
     </div>
 }

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -1,8 +1,5 @@
 import { useParams } from "react-router";
-import NavigationBar from "~/components/layout/NavigationBar";
-import NavigationItem from "~/components/layout/NavigationItem";
-import Me from "~/components/ui/Me";
-import BackArrowIcon from "~/assets/back-arrow.svg?react";
+import AppShell from "~/components/layout/AppShell";
 import SaveIcon from "~/assets/save.svg?react";
 import QuestionMarkSquareIcon from "~/assets/question-mark-squre.svg?react";
 import DeleteIcon from "~/assets/delete.svg?react";
@@ -162,14 +159,12 @@ export default function PlaylistWriteView() {
 	}
 
 	return (
-		<div className="flex flex-row w-full h-full">
-			<NavigationBar>
-				<div className="grow shrink flex flex-col gap-4">
-					<NavigationItem onClick={() => setIsBackModalOpen(true)} icon={<BackArrowIcon></BackArrowIcon>} title={"뒤로가기"}></NavigationItem>
-					<NavigationItem onClick={onClickSave} icon={<SaveIcon></SaveIcon>} title={"저장하기"}></NavigationItem>
-				</div>
-				<div className="grow-0 shrink-0"><Me></Me></div>
-			</NavigationBar>
+		<AppShell
+			variant="sub"
+			title="새 플레이리스트"
+			onBack={() => setIsBackModalOpen(true)}
+			actions={[{ icon: <SaveIcon />, label: "저장하기", onClick: onClickSave }]}
+		>
 			<ColumnsContainer>
 				<Column1>
 					<p className="text-4xl font-bold p-4">새 플레이리스트</p>
@@ -309,6 +304,6 @@ export default function PlaylistWriteView() {
 				>
 				</TrackCreateLayer>
 			</Modal>
-		</div>
+		</AppShell>
 	)
 }

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -1,9 +1,5 @@
 import {Link} from "react-router";
-import NavigationBar from "~/components/layout/NavigationBar";
-import NavigationItem from "~/components/layout/NavigationItem";
-import Me from "~/components/ui/Me";
-import RoomIcon from "~/assets/room.svg?react";
-import PlaylistIcon from "~/assets/playlist.svg?react"
+import AppShell from "~/components/layout/AppShell";
 import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import Column1 from "~/components/layout/Column1";
 import SelectMenu from "~/components/ui/SelectMenu";
@@ -134,16 +130,7 @@ export default function PlaylistsView() {
     }
 
     return (
-        <div className="flex flex-row w-full h-full">
-            <NavigationBar>
-                <div className="grow shrink flex flex-col gap-4">
-                    <Link to="/" replace>
-                        <NavigationItem icon={<RoomIcon></RoomIcon>} title={"플레이 룸"}></NavigationItem>
-                    </Link>
-                    <NavigationItem clicked icon={<PlaylistIcon></PlaylistIcon>} title={"플레이리스트"}></NavigationItem>
-                </div>
-                <div className="grow-0 shrink-0"><Me></Me></div>
-            </NavigationBar>
+        <AppShell variant="main" activeTab="playlists" title="플레이리스트">
             <ColumnsContainer>
                 <Column1>
                     <div className="flex flex-row px-4 pt-4 gap-4">
@@ -299,6 +286,6 @@ export default function PlaylistsView() {
                     </div>
                 </div>
             )}
-        </div>
+        </AppShell>
     );
 }

--- a/front/app/routes/RoomView.tsx
+++ b/front/app/routes/RoomView.tsx
@@ -1,12 +1,8 @@
 import { useParams } from "react-router";
-import NavigationBar from "~/components/layout/NavigationBar";
-import NavigationItem from "~/components/layout/NavigationItem";
-import Me from "~/components/ui/Me";
-import BackIcon from "~/assets/back.svg?react";
+import AppShell from "~/components/layout/AppShell";
 import PlayIcon from "~/assets/play.svg?react";
 import PlaylistIcon from "~/assets/playlist.svg?react";
 import UsersIcon from "~/assets/users.svg?react";
-import { Link } from "react-router";
 import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import Column1 from "~/components/layout/Column1";
 import Column2 from "~/components/layout/Column2";
@@ -19,19 +15,12 @@ export default function RoomView() {
     const playlistDescription = "오늘의 일본 인기곡 Top 100으로 구성된 맵입니다. 재미있게 즐겨 주세요!"
 
     return (
-        <div className="flex flex-row w-full h-full">
-            <NavigationBar>
-                <div className="grow shrink flex flex-col gap-4">
-                    <Link to="/" replace>
-                        <NavigationItem icon={<BackIcon></BackIcon>} title={"뒤로가기"}>
-                        </NavigationItem>
-                    </Link>
-                    <NavigationItem icon={<PlayIcon></PlayIcon>} title={"시작하기"}></NavigationItem>
-                </div>
-                <div className="grow-0 shrink-0">
-                    <Me></Me>
-                </div>
-            </NavigationBar>
+        <AppShell
+            variant="sub"
+            title={title}
+            backTo="/"
+            actions={[{ icon: <PlayIcon />, label: "시작하기", onClick: () => {} }]}
+        >
             <ColumnsContainer>
                 <Column1>
                     <p className="text-4xl pt-4 font-bold">{title}</p>
@@ -93,6 +82,6 @@ export default function RoomView() {
                     </div>
                 </Column2>
             </ColumnsContainer>
-        </div>
+        </AppShell>
     );
 };

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -1,8 +1,4 @@
-import NavigationBar from "~/components/layout/NavigationBar";
-import NavigationItem from "~/components/layout/NavigationItem";
-import RoomIcon from "~/assets/room.svg?react";
-import PlaylistIcon from "~/assets/playlist.svg?react"
-import Me from "~/components/ui/Me";
+import AppShell from "~/components/layout/AppShell";
 import SearchBar from "~/components/ui/SearchBar";
 import React, {useEffect, useState} from "react";
 import { Link } from "react-router";
@@ -67,16 +63,7 @@ export default function RoomsView() {
     }, []);
 
     return (
-        <div className="flex flex-row w-full h-full">
-            <NavigationBar >
-                <div className="grow shrink flex flex-col gap-4">
-                    <NavigationItem clicked icon={<RoomIcon></RoomIcon>} title={"플레이 룸"}></NavigationItem>
-                    <Link to="/playlists" replace>
-                        <NavigationItem icon={<PlaylistIcon></PlaylistIcon>} title={"플레이리스트"}></NavigationItem>
-                    </Link>
-                </div>
-                <div className="grow-0 shrink-0"><Me></Me></div>
-            </NavigationBar>
+        <AppShell variant="main" activeTab="rooms" title="플레이 룸">
             <ColumnsContainer>
                 <div className="mx-2 pt-4 px-4 gap-4 w-full flex flex-col items-center">
                     <div className="w-full max-w-2xl">
@@ -119,6 +106,6 @@ export default function RoomsView() {
                 </div>
             </ColumnsContainer>
             {showCreate && <RoomCreate onClose={() => setShowCreate(false)} />}
-        </div>
+        </AppShell>
       );
 }

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -65,7 +65,7 @@ export default function RoomsView() {
     return (
         <AppShell variant="main" activeTab="rooms" title="플레이 룸">
             <ColumnsContainer>
-                <div className="mx-2 pt-4 px-4 gap-4 w-full flex flex-col items-center">
+                <div className="pt-4 px-4 gap-4 w-full flex flex-col items-center">
                     <div className="w-full max-w-2xl">
                         <SearchBar query={query} setQuery={setQuery}></SearchBar>
                     </div>


### PR DESCRIPTION
## Summary
- 4개 라우트 뷰(RoomsView, RoomView, PlaylistsView, PlaylistWriteView)의 레이아웃 래퍼를 AppShell로 교체
- NavigationBar + NavigationItem + Me 직접 조합 코드 제거 → AppShell에 위임
- 각 뷰의 비즈니스 로직, 콘텐츠, 모달은 그대로 유지 (레이아웃 래퍼만 교체)
- 42줄 순감소 (64줄 삭제, 22줄 추가)

Closes #136

## Test plan
- [ ] RoomsView(`/`): 데스크톱에서 72px 사이드바 + 방 목록 그리드 표시, 모바일에서 MobileHeader + MobileBottomNav 표시
- [ ] RoomView(`/rooms/:id`): 데스크톱에서 뒤로가기 + 시작하기 사이드바, 모바일에서 ← + 제목 + 시작하기 헤더 표시
- [ ] PlaylistsView(`/playlists`): 데스크톱에서 탭 + 목록 + 상세 2컬럼, 모바일에서 단일 컬럼 스택
- [ ] PlaylistWriteView(`/playlists/create`): 뒤로가기 시 모달 확인 정상 동작, 저장 버튼 정상 동작
- [ ] 모든 기존 모달(RoomCreate, 삭제 확인, Back/Alert/TrackCreate) 정상 동작
- [ ] 320px ~ 1920px 범위에서 레이아웃 깨짐 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)