### PR TITLE
feat: Modal 리디자인

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -66,6 +66,10 @@
   from { opacity: 0; transform: scale(0.95); }
   to { opacity: 1; transform: scale(1); }
 }
+@keyframes scale-out {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.95); }
+}
 @keyframes slide-down {
   from { opacity: 0; transform: translateY(-8px); }
   to { opacity: 1; transform: translateY(0); }
@@ -75,10 +79,13 @@
   animation: fade-in 0.2s ease-out;
 }
 @utility animate-fade-out {
-  animation: fade-out 0.2s ease-out;
+  animation: fade-out 0.2s ease-out forwards;
 }
 @utility animate-scale-in {
   animation: scale-in 0.2s ease-out;
+}
+@utility animate-scale-out {
+  animation: scale-out 0.2s ease-out forwards;
 }
 @utility animate-slide-down {
   animation: slide-down 0.2s ease-out;

--- a/front/app/components/ui/Modal.tsx
+++ b/front/app/components/ui/Modal.tsx
@@ -1,3 +1,5 @@
+import {type AnimationEvent, useEffect, useState} from "react";
+
 interface ModalProps {
     isOpen: boolean;
     onClose: () => void;
@@ -5,16 +7,41 @@ interface ModalProps {
 }
 
 export default function Modal({ isOpen, onClose, children }: ModalProps) {
-    if (!isOpen) return null;
+    const [visible, setVisible] = useState(false);
+    const [closing, setClosing] = useState(false);
+
+    useEffect(() => {
+        if (isOpen) {
+            setVisible(true);
+            setClosing(false);
+        } else if (visible) {
+            setClosing(true);
+        }
+    }, [isOpen]);
+
+    function handleClose() {
+        setClosing(true);
+    }
+
+    function handleAnimationEnd(e: AnimationEvent) {
+        if (closing && e.currentTarget === e.target) {
+            setVisible(false);
+            setClosing(false);
+            onClose();
+        }
+    }
+
+    if (!visible) return null;
 
     return (
-        <div 
-            className="fixed inset-0 flex items-center justify-center bg-black/50"
-            onClick={onClose}
+        <div
+            className={`fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "animate-fade-out" : "animate-fade-in"}`}
+            onClick={handleClose}
+            onAnimationEnd={handleAnimationEnd}
         >
             <div
-                className="bg-zinc-900 opacity-100 p-6 rounded-2xl shadow-lg"
-                onClick={(e) => e.stopPropagation()} // 내부 클릭 시 닫히지 않도록 설정
+                className={`bg-surface border border-border p-6 rounded-2xl shadow-glow-cyan ${closing ? "animate-scale-out" : "animate-scale-in"}`}
+                onClick={(e) => e.stopPropagation()}
             >
                 {children}
             </div>


### PR DESCRIPTION
## Summary
- Modal 오버레이에 `bg-black/60 backdrop-blur-sm` 적용
- 컨테이너 스타일을 `bg-surface border-border shadow-glow-cyan`으로 변경
- 등장 애니메이션: `animate-fade-in` (오버레이) + `animate-scale-in` (컨테이너)
- 퇴장 애니메이션: `closing` 상태 기반 `animate-fade-out` + `animate-scale-out` 후 언마운트
- `app.css`에 `scale-out` keyframe 및 `animate-scale-out` 유틸리티 추가
- Props 인터페이스(`isOpen`, `onClose`, `children`) 유지 — 호출부 변경 없음

Closes #140

## Test plan
- [ ] Modal 열기 시 fade+scale 등장 애니메이션 동작 확인
- [ ] 오버레이 클릭 시 fade-out+scale-out 퇴장 애니메이션 후 닫힘 확인
- [ ] 오버레이에 백드롭 블러 적용 확인
- [ ] 컨테이너에 Surface 배경 + 글로우 보더 렌더링 확인
- [ ] PlaylistWriteView에서 기존 Modal 사용이 변경 없이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)