### PR TITLE
feat: SearchBar & 입력 필드 스타일 리디자인

### DIFF
--- a/front/app/components/ui/AdditionalTitleEditor.tsx
+++ b/front/app/components/ui/AdditionalTitleEditor.tsx
@@ -32,7 +32,7 @@ export default function AdditionalTitleEditor({maxAdditionalTitlesCount, additio
     }
 
     return (
-        <div className={"flex-1 h-10 p-2 shrink text-zinc-200 rounded-full " + (canInput() ? "bg-zinc-600" : "bg-zinc-800")}>
+        <div className={"flex-1 h-10 p-2 shrink border text-zinc-200 rounded-full transition-all duration-200 " + (canInput() ? "bg-surface border-border focus-within:border-neon-cyan focus-within:shadow-glow-cyan" : "bg-zinc-800 border-border")}>
             <input
                 disabled={!canInput()}
                 type="text"
@@ -41,7 +41,7 @@ export default function AdditionalTitleEditor({maxAdditionalTitlesCount, additio
                 maxLength={maxTitleLength}
                 onChange={(e) => {setAdditionalTitle(e.target.value)}}
                 onKeyDown={handleInputKeyDown}
-                className="w-full pl-[8px] focus:outline-none"
+                className="w-full pl-[8px] placeholder-zinc-500 focus:outline-none"
             />
         </div>
     )

--- a/front/app/components/ui/RoomCreate.tsx
+++ b/front/app/components/ui/RoomCreate.tsx
@@ -185,7 +185,7 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
                             {!selectedPlaylist && (
                                 <input
                                     type="text"
-                                    className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-secondary transition"
+                                    className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-neon-cyan focus:shadow-glow-cyan transition-all duration-200"
                                     placeholder="플레이리스트 검색"
                                     value={searchTerm}
                                     onChange={e => {
@@ -248,7 +248,7 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
                         <label className="block mb-2 text-sm font-semibold text-zinc-300">방 이름</label>
                         <input
                             type="text"
-                            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-secondary transition"
+                            className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-neon-cyan focus:shadow-glow-cyan transition-all duration-200"
                             placeholder="1자 이상 입력"
                             value={roomName}
                             onChange={e => setRoomName(e.target.value)}
@@ -261,7 +261,7 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
                     <div>
                         <label className="block mb-2 text-sm font-semibold text-zinc-300">최대 인원수</label>
                         <select
-                            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-secondary transition"
+                            className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-zinc-100 focus:outline-none focus:border-neon-cyan focus:shadow-glow-cyan transition-all duration-200"
                             value={selectedRoomCapacity}
                             onChange={e => setSelectedRoomCapacity(Number(e.target.value))}
                         >
@@ -282,7 +282,7 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
                             />
                             <input
                                 type="password"
-                                className={`w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-secondary transition ${!usePassword ? 'opacity-50' : ''}`}
+                                className={`w-full rounded-lg border border-border bg-surface px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:outline-none focus:border-neon-cyan focus:shadow-glow-cyan transition-all duration-200 ${!usePassword ? 'opacity-50' : ''}`}
                                 placeholder="비밀번호 입력"
                                 value={password}
                                 onChange={e => setPassword(e.target.value)}

--- a/front/app/components/ui/SearchBar.tsx
+++ b/front/app/components/ui/SearchBar.tsx
@@ -8,7 +8,7 @@ interface SearchBarProps {
 export default function SearchBar({ query, setQuery }: SearchBarProps) {
     return (
       <div className="w-full p-[8px]">
-        <div className="group w-full h-[48px] p-[8px] flex flex-row rounded-full bg-surface border border-border group-focus-within:border-neon-cyan group-focus-within:shadow-glow-cyan transition-all duration-200">
+        <div className="group w-full h-[48px] p-[8px] flex flex-row rounded-full bg-surface border border-border focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
             <SearchIcon className="size-[24px] m-[4px] text-muted group-focus-within:text-neon-cyan transition-all duration-200"></SearchIcon>
             <input
                 type="text"

--- a/front/app/components/ui/SearchBar.tsx
+++ b/front/app/components/ui/SearchBar.tsx
@@ -8,14 +8,14 @@ interface SearchBarProps {
 export default function SearchBar({ query, setQuery }: SearchBarProps) {
     return (
       <div className="w-full p-[8px]">
-        <div className="w-full h-[48px] p-[8px] flex flex-row rounded-full bg-zinc-700">
-            <SearchIcon className="size-[24px] m-[4px]"></SearchIcon>
+        <div className="group w-full h-[48px] p-[8px] flex flex-row rounded-full bg-surface border border-border group-focus-within:border-neon-cyan group-focus-within:shadow-glow-cyan transition-all duration-200">
+            <SearchIcon className="size-[24px] m-[4px] text-muted group-focus-within:text-neon-cyan transition-all duration-200"></SearchIcon>
             <input
                 type="text"
                 placeholder="방 이름, 플레이리스트, 플레이어 이름으로 검색"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                className="w-full p-[2px] pl-[8px] focus:outline-none"
+                className="w-full p-[2px] pl-[8px] placeholder-zinc-500 focus:outline-none"
             />
         </div>   
       </div>

--- a/front/app/components/ui/TrackEditLayer.tsx
+++ b/front/app/components/ui/TrackEditLayer.tsx
@@ -164,28 +164,28 @@ export default function TrackCreateLayer(props: TrackEditLayerProps) {
 				<div className="flex flex-col gap-2 w-2xl">
 					<div className="flex flex-col px-4 gap-1">
 						<p className="px-4">YouTube URL</p>
-						<div className="flex-1 h-10 p-2 shrink bg-zinc-600 text-zinc-200 rounded-full">
+						<div className="flex-1 h-10 p-2 shrink bg-surface border border-border text-zinc-200 rounded-full focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
 							<input
 								type="text"
 								placeholder="YouTube URL"
 								value={youTubeUrl}
 								onChange={(e) => {setYouTubeUrl(e.target.value)}}
 								maxLength={100}
-								className="w-full pl-[8px] focus:outline-none"
+								className="w-full pl-[8px] placeholder-zinc-500 focus:outline-none"
 							/>
 						</div>
 						<p className="px-4 text-xs text-red-600 h-2">{isValidYoutubeUrl() ? " " : "올바른 URL을 입력해 주세요."}</p>
 					</div>
 					<div className="flex flex-col px-4 gap-1">
 						<p className="px-4">제목</p>
-						<div className="flex-1 h-10 p-2 shrink bg-zinc-600 text-zinc-200 rounded-full">
+						<div className="flex-1 h-10 p-2 shrink bg-surface border border-border text-zinc-200 rounded-full focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
 							<input
 								type="text"
 								placeholder="제목"
 								value={title}
 								onChange={(e) => {setTitle(e.target.value)}}
 								maxLength={maxTitleLength}
-								className="w-full pl-[8px] focus:outline-none"
+								className="w-full pl-[8px] placeholder-zinc-500 focus:outline-none"
 							/>
 						</div>
 						<p className="px-4 text-xs text-red-600 h-2">{isValidTitle() ? " " : "제목을 입력해 주세요."}</p>

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -181,20 +181,20 @@ export default function PlaylistWriteView() {
 					</div>
 					<div className="flex flex-col px-4 gap-2">
 						<p className="text-2xl font-bold">이름</p>
-						<div className="w-full h-10 p-2 shrink bg-zinc-600 text-zinc-200 rounded-full">
+						<div className="w-full h-10 p-2 shrink bg-surface border border-border text-zinc-200 rounded-full focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
 							<input
 								type="text"
 								placeholder="이름"
 								value={title}
 								onChange={(e) => setTitle(e.target.value)}
 								maxLength={maxTitleLength}
-								className="w-full pl-[8px] focus:outline-none"
+								className="w-full pl-[8px] placeholder-zinc-500 focus:outline-none"
 							/>
 						</div>
 					</div>
 					<div className="flex flex-col px-4 gap-2">
 						<p className="text-2xl font-bold">소개</p>
-						<div className="w-full p-2 shrink bg-zinc-600 text-zinc-200 rounded-2xl">
+						<div className="w-full p-2 shrink bg-surface border border-border text-zinc-200 rounded-2xl focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
                             <textarea
 								rows={1}
 								ref={descriptionRef}
@@ -208,7 +208,7 @@ export default function PlaylistWriteView() {
 								onInput={handleDescriptionInput}
 								onChange={(e) => setDescription(e.target.value)}
 								maxLength={maxDescriptionLength}
-								className="w-full pl-[8px] resize-none overflow-hidden focus:outline-none"
+								className="w-full pl-[8px] placeholder-zinc-500 resize-none overflow-hidden focus:outline-none"
 							/>
 						</div>
 					</div>

--- a/front/app/routes/RoomView.tsx
+++ b/front/app/routes/RoomView.tsx
@@ -73,11 +73,11 @@ export default function RoomView() {
                             </div>
                         </div>
                     </div>
-                    <div className="p-2 m-2 rounded-full bg-zinc-700">
+                    <div className="p-2 m-2 rounded-full bg-surface border border-border focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
                         <input
                             type="text"
                             placeholder="보낼 메시지 입력"
-                            className="w-full p-[2px] pl-[8px] focus:outline-none"
+                            className="w-full p-[2px] pl-[8px] placeholder-zinc-500 focus:outline-none"
                         />
                     </div>
                 </Column2>


### PR DESCRIPTION
## Summary
- SearchBar 컨테이너에 `group` 클래스 기반 네온 포커스 효과 적용 (글로우 보더 + 아이콘 색상 전환)
- 전체 입력 필드(input, textarea, select)를 디자인 토큰(`bg-surface`, `border-border`) 기반으로 통일
- 포커스 시 `border-neon-cyan` + `shadow-glow-cyan` 글로우 효과 일관 적용
- placeholder 색상을 `placeholder-zinc-500`으로 통일

Closes #141

## Test plan
- [x] SearchBar 포커스 시 네온 cyan 글로우 보더 + 아이콘 색상 전환 확인
- [x] PlaylistWriteView 제목 input, 소개 textarea 포커스 효과 확인
- [x] TrackEditLayer URL/제목 input 포커스 효과 확인
- [x] RoomCreate 플레이리스트 검색, 방이름, 최대 인원수 select, 비밀번호 input 스타일 확인
- [x] RoomView 채팅 input 포커스 효과 확인
- [x] 모든 입력 필드의 placeholder 색상이 일관되게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)