### PR TITLE
feat: 뷰 토스트 적용 및 버튼 마이그레이션

### DIFF
--- a/front/app/components/ui/Button.tsx
+++ b/front/app/components/ui/Button.tsx
@@ -1,6 +1,6 @@
 import { type ButtonHTMLAttributes } from "react";
 
-type Variant = "primary" | "secondary" | "ghost" | "danger";
+type Variant = "primary" | "secondary" | "ghost" | "danger" | "icon";
 type Size = "sm" | "md" | "lg";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -19,6 +19,8 @@ const variantStyles: Record<Variant, string> = {
         "bg-transparent text-zinc-400 border border-transparent hover:bg-zinc-800 hover:text-zinc-200",
     danger:
         "bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30",
+    icon:
+        "size-10 p-0 rounded-full bg-zinc-700 text-zinc-300 border border-transparent hover:bg-zinc-600 hover:text-zinc-100",
 };
 
 const sizeStyles: Record<Size, string> = {
@@ -46,7 +48,7 @@ export default function Button({
                 inline-flex items-center justify-center font-medium
                 transition-all duration-200 cursor-pointer
                 ${variantStyles[variant]}
-                ${sizeStyles[size]}
+                ${variant !== "icon" ? sizeStyles[size] : ""}
                 ${fullWidth ? "w-full" : ""}
                 ${isDisabled ? "opacity-50 cursor-not-allowed pointer-events-none" : ""}
                 ${className}

--- a/front/app/components/ui/Dropdown.tsx
+++ b/front/app/components/ui/Dropdown.tsx
@@ -36,7 +36,7 @@ export default function Dropdown({values, selectedValue, setValue}: DropdownProp
                 <button
                     type="button"
                     onClick={toggleDropdown}
-                    className="inline-flex flex flex-row w-full rounded-full p-2 h-10 bg-surface border border-border pl-[16px] transition-all duration-200 hover:border-neon-cyan"
+                    className="inline-flex flex flex-row w-full rounded-full p-2 h-10 bg-surface border border-border pl-[16px] transition-colors duration-200 hover:border-neon-cyan"
                 >
                     <p className="flex-1">{ selectedValue }</p>
                     {isOpen
@@ -46,7 +46,7 @@ export default function Dropdown({values, selectedValue, setValue}: DropdownProp
                 </button>
             </div>
 
-            <div className={`absolute right-0 mt-2 w-full rounded-2xl bg-card border border-border shadow-glow-cyan transition-all duration-200 origin-top ${isOpen ? "opacity-100 translate-y-0 scale-100" : "opacity-0 -translate-y-2 scale-95 pointer-events-none"}`}>
+            <div className={`absolute right-0 mt-2 w-full rounded-2xl bg-card border border-border shadow-glow-cyan transition-[opacity,transform] duration-200 origin-top ${isOpen ? "opacity-100 translate-y-0 scale-100" : "opacity-0 -translate-y-2 scale-95 pointer-events-none"}`}>
                     <div>
                         {
                             values.map((value, index) =>

--- a/front/app/components/ui/Dropdown.tsx
+++ b/front/app/components/ui/Dropdown.tsx
@@ -40,23 +40,25 @@ export default function Dropdown({values, selectedValue, setValue}: DropdownProp
                 >
                     <p className="flex-1">{ selectedValue }</p>
                     {isOpen
-                        ? <DropUpIcon className={`size-6 transition-all duration-200 ${isOpen ? "text-neon-cyan" : ""}`}></DropUpIcon>
-                        : <DropDownIcon className="size-6 transition-all duration-200"></DropDownIcon>
+                        ? <DropUpIcon className="size-6 text-neon-cyan"></DropUpIcon>
+                        : <DropDownIcon className="size-6"></DropDownIcon>
                     }
                 </button>
             </div>
 
-            <div className={`absolute right-0 mt-2 w-full rounded-2xl bg-card border border-border shadow-glow-cyan transition-[opacity,transform] duration-200 origin-top ${isOpen ? "opacity-100 translate-y-0 scale-100" : "opacity-0 -translate-y-2 scale-95 pointer-events-none"}`}>
+            {isOpen && (
+                <div className="absolute right-0 mt-2 w-full rounded-2xl bg-card border border-border shadow-glow-cyan origin-top animate-scale-in z-10">
                     <div>
                         {
                             values.map((value, index) =>
-                                <p key={index} onClick={() => clickValue(value)} className="block rounded-2xl px-4 py-2 transition-all duration-200 hover:bg-neon-cyan/10 hover:text-neon-cyan">
+                                <p key={index} onClick={() => clickValue(value)} className="block rounded-2xl px-4 py-2 transition-colors duration-200 hover:bg-neon-cyan/10 hover:text-neon-cyan cursor-pointer">
                                     { value }
                                 </p>
                             )
                         }
                     </div>
                 </div>
+            )}
         </div>
   )
 }

--- a/front/app/components/ui/Modal.tsx
+++ b/front/app/components/ui/Modal.tsx
@@ -40,7 +40,7 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
             onAnimationEnd={handleAnimationEnd}
         >
             <div
-                className={`bg-surface border border-border p-6 rounded-2xl shadow-glow-cyan ${closing ? "animate-scale-out" : "animate-scale-in"}`}
+                className={`bg-surface border border-border p-6 rounded-2xl shadow-glow-cyan max-h-[90vh] overflow-y-auto mx-4 ${closing ? "animate-scale-out" : "animate-scale-in"}`}
                 onClick={(e) => e.stopPropagation()}
             >
                 {children}

--- a/front/app/components/ui/RoomCreate.tsx
+++ b/front/app/components/ui/RoomCreate.tsx
@@ -303,7 +303,7 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
                             disabled={!isValidForm}
                             onClick={() => {
                                 if (!isValidForm) return;
-                                // TODO: 실제 방 생성 API 호출
+                                // TODO: 실제 방 생성 API 호출 후 toast.success() 표시
                                 onClose();
                             }}
                         >

--- a/front/app/components/ui/Toast.tsx
+++ b/front/app/components/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import { Toaster as SonnerToaster } from "sonner";
+import "sonner/dist/styles.css";
 
 export default function Toaster() {
     return (

--- a/front/app/components/ui/TrackEditLayer.tsx
+++ b/front/app/components/ui/TrackEditLayer.tsx
@@ -5,6 +5,7 @@ import CloseIcon from "~/assets/close.svg?react"
 import StarIcon from "~/assets/star.svg?react"
 import FilledStarIcon from "~/assets/filled-star.svg?react"
 import Dropdown from "./Dropdown"
+import Button from "./Button"
 import { getEmbedIdByUrl, getUrlByEmbedId } from "~/utils/youtube"
 import YouTube from "react-youtube"
 
@@ -223,14 +224,8 @@ export default function TrackCreateLayer(props: TrackEditLayerProps) {
 				</div>
 			</div>
             <div className="flex flex-row mt-6 gap-2">
-                <button
-                    className={"flex-1 rounded-full p-2 grow font-bold " + (isValidInput() ? "bg-cyan-400 text-zinc-900 cursor-pointer" : "bg-zinc-800 text-zinc-100")}
-                    onClick={submit}
-                >확인</button>
-                <button
-                    className="flex-1 rounded-full p-2 grow bg-zinc-700 text-zinc-100 font-bold cursor-pointer"
-                    onClick={props.onClose}
-                >취소</button>
+                <Button variant="primary" fullWidth disabled={!isValidInput()} onClick={submit}>확인</Button>
+                <Button variant="secondary" fullWidth onClick={props.onClose}>취소</Button>
             </div>
         </div>
     )

--- a/front/app/components/ui/TrackEditLayer.tsx
+++ b/front/app/components/ui/TrackEditLayer.tsx
@@ -155,14 +155,14 @@ export default function TrackCreateLayer(props: TrackEditLayerProps) {
 					&& (isRepresentative() ? <FilledStarIcon></FilledStarIcon>
 						: <StarIcon className="cursor-pointer" onClick={() => props.setRepresentativeIndex(props.selectedIndex)}></StarIcon>) }
 			</div>
-			<div className="flex flex-row items-center gap-2">
-				<div className="p-2">
+			<div className="flex flex-col md:flex-row md:items-center gap-2">
+				<div className="p-2 flex justify-center">
 					{ getEmbedIdByUrl(youTubeUrl) ?
 						<YouTube videoId={getEmbedIdByUrl(youTubeUrl) ?? ""} opts={youTubeOptions} onReady={onYouTubeReady}></YouTube>
 						: <div className="w-80 h-45 bg-black"></div>
 					}
 				</div>
-				<div className="flex flex-col gap-2 w-2xl">
+				<div className="flex flex-col gap-2 w-full md:w-2xl">
 					<div className="flex flex-col px-4 gap-1">
 						<p className="px-4">YouTube URL</p>
 						<div className="flex-1 h-10 p-2 shrink bg-surface border border-border text-zinc-200 rounded-full focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -14,6 +14,8 @@ import Column2 from "~/components/layout/Column2";
 import TrackCreateLayer, {type Track} from "~/components/ui/TrackEditLayer";
 import {createPlaylist, fetchPlaylistWithTracks, modifyPlaylist} from "~/utils/api";
 import type { AxiosError } from "axios";
+import { toast } from "sonner";
+import Button from "~/components/ui/Button";
 
 export default function PlaylistWriteView() {
 	const { playlistId } = useParams();
@@ -25,8 +27,6 @@ export default function PlaylistWriteView() {
 	const [description, setDescription] = useState("")
 	const [tracks, setTracks] = useState<Track[]>([])
 	const [representativeIndex, setRepresentativeIndex] = useState<number | null>(null)
-	const [isAlertModalOpen, setIsAlertModalOpen] = useState(false)
-	const [alertMessage, setAlertMessage] = useState("")
 	const descriptionRef = useRef<HTMLTextAreaElement>(null)
 	const navigate = useNavigate()
 	const maxTitleLength = 100
@@ -100,33 +100,27 @@ export default function PlaylistWriteView() {
 
 	async function onClickSave() {
 		if (title.trim() === "") {
-			setAlertMessage("플레이리스트 이름을 입력해주세요.")
-			setIsAlertModalOpen(true)
+			toast.error("플레이리스트 이름을 입력해주세요.")
 			return
 		}
 		if (title.trim().length > maxTitleLength) {
-			setAlertMessage(`플레이리스트 이름은 ${maxTitleLength}자를 초과할 수 없습니다.`)
-			setIsAlertModalOpen(true)
+			toast.error(`플레이리스트 이름은 ${maxTitleLength}자를 초과할 수 없습니다.`)
 			return
 		}
 		if (description.trim() === "") {
-			setAlertMessage("플레이리스트 소개를 입력해주세요.")
-			setIsAlertModalOpen(true)
+			toast.error("플레이리스트 소개를 입력해주세요.")
 			return
 		}
 		if (description.trim().length > maxDescriptionLength) {
-			setAlertMessage(`플레이리스트 소개는 ${maxDescriptionLength}자를 초과할 수 없습니다.`)
-			setIsAlertModalOpen(true)
+			toast.error(`플레이리스트 소개는 ${maxDescriptionLength}자를 초과할 수 없습니다.`)
 			return
 		}
 		if (tracks.length === 0) {
-			setAlertMessage("플레이리스트에 곡을 추가해주세요.")
-			setIsAlertModalOpen(true)
+			toast.error("플레이리스트에 곡을 추가해주세요.")
 			return
 		}
 		if (representativeIndex === null) {
-			setAlertMessage("대표곡을 선택해주세요.")
-			setIsAlertModalOpen(true)
+			toast.error("대표곡을 선택해주세요.")
 			return
 		}
 
@@ -150,11 +144,11 @@ export default function PlaylistWriteView() {
 			} else {
 				await createPlaylist(request);
 			}
+			toast.success("플레이리스트가 저장되었습니다.")
 			navigate("/playlists");
 		} catch (error) {
 			const axiosError = error as AxiosError<{message: string}>;
-			setAlertMessage(axiosError.response?.data?.message ?? "알 수 없는 오류가 발생했습니다.");
-			setIsAlertModalOpen(true);
+			toast.error(axiosError.response?.data?.message ?? "알 수 없는 오류가 발생했습니다.");
 		}
 	}
 
@@ -261,28 +255,8 @@ export default function PlaylistWriteView() {
 					<h2 className="text-xl font-bold mb-4">뒤로가기</h2>
 					<p>수정 중인 플레이리스트를 저장하지 않고 뒤로 가시겠습니까?</p>
 					<div className="flex flex-row mt-6 gap-2">
-						<button
-							className="rounded-full p-2 grow bg-cyan-400 text-zinc-900 font-bold cursor-pointer"
-							onClick={goBack}
-						>확인
-						</button>
-						<button
-							className="rounded-full p-2 grow bg-zinc-200 text-zinc-900 font-bold cursor-pointer"
-							onClick={() => setIsBackModalOpen(false)}
-						>취소
-						</button>
-					</div>
-				</div>
-			</Modal>
-			<Modal isOpen={isAlertModalOpen} onClose={() => setIsAlertModalOpen(false)}>
-				<div className="flex flex-col w-full">
-					<p>{alertMessage}</p>
-					<div className="flex flex-row mt-6 gap-2">
-						<button
-							className="rounded-full p-2 grow bg-cyan-400 text-zinc-900 font-bold cursor-pointer"
-							onClick={() => setIsAlertModalOpen(false)}
-						>닫기
-						</button>
+						<Button variant="primary" fullWidth onClick={goBack}>확인</Button>
+						<Button variant="secondary" fullWidth onClick={() => setIsBackModalOpen(false)}>취소</Button>
 					</div>
 				</div>
 			</Modal>

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -161,11 +161,11 @@ export default function PlaylistWriteView() {
 		>
 			<ColumnsContainer>
 				<Column1>
-					<p className="text-4xl font-bold p-4">새 플레이리스트</p>
+					<p className="hidden md:block text-4xl font-bold p-4">새 플레이리스트</p>
 					<div className="flex flex-col px-6 gap-2">
 						<p className="text-2xl font-bold">썸네일</p>
 						<p className="px-2 text-zinc-400">썸네일은 대표곡 기준으로 표시됩니다.</p>
-						<div className="mx-auto w-full max-w-96 aspect-square">
+						<div className="mx-auto w-full max-w-48 md:max-w-96 aspect-square">
 							{
 								representativeIndex !== null ?
 									<img className="w-full h-full object-contain rounded-2xl" src={`https://img.youtube.com/vi/${tracks[representativeIndex].embedId}/maxresdefault.jpg`} alt={tracks[representativeIndex].title} draggable={false}/>
@@ -208,7 +208,7 @@ export default function PlaylistWriteView() {
 					</div>
 				</Column1>
 				<Column2>
-					<div className="flex flex-row gap-2 mt-22 items-end px-4">
+					<div className="flex flex-row gap-2 mt-4 md:mt-22 items-end px-4">
 						<p className="text-2xl font-bold">곡 목록</p>
 						<p>{`${tracks.length}곡(최대 ${Math.ceil(expectedPlaytime() / 60)}분)`}</p>
 					</div>

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -26,6 +26,8 @@ import FilledStarIcon from "~/assets/filled-star.svg?react";
 import PencilIcon from "~/assets/pencil.svg?react";
 import DeleteIcon from "~/assets/delete.svg?react";
 import useMeStore from "~/stores/MeStore";
+import { toast } from "sonner";
+import Button from "~/components/ui/Button";
 
 export default function PlaylistsView() {
     const searchTypes = ["제목", "제작자"];
@@ -98,8 +100,10 @@ export default function PlaylistsView() {
         try {
             if (optimistic.favorite) {
                 await favoritePlaylist(playlistId);
+                toast.info("즐겨찾기에 추가되었습니다.");
             } else {
                 await unfavoritePlaylist(playlistId);
+                toast.info("즐겨찾기가 해제되었습니다.");
             }
             // 즐겨찾기 탭에서 해제한 경우 목록 새로고침
             if (selectedTab === "favorite") {
@@ -107,6 +111,7 @@ export default function PlaylistsView() {
             }
         } catch (e) {
             setSelectedPlaylist({...selectedPlaylist});
+            toast.error("즐겨찾기 변경에 실패했습니다.");
         } finally {
             setFavoriteUpdating(false);
         }
@@ -120,9 +125,9 @@ export default function PlaylistsView() {
             setPlaylists(prev => prev.filter(p => p.id !== selectedPlaylist.id));
             setSelectedPlaylist(null);
             setSelectedPlaylistId(null);
+            toast.success("플레이리스트가 삭제되었습니다.");
         } catch (e) {
-            // 단순 경고 (필요시 향후 토스트로 대체 가능)
-            alert("삭제 중 문제가 발생했습니다.");
+            toast.error("삭제 중 문제가 발생했습니다.");
         } finally {
             setDeleting(false);
             setShowDeleteConfirm(false);
@@ -188,10 +193,7 @@ export default function PlaylistsView() {
                         }
                     </div>
                     <Link className="w-full pb-4" to="/playlists/create">
-                        <button
-                            className="w-full bg-cyan-400 py-2 text-zinc-900 rounded-full cursor-pointer text-2xl font-bold">
-                            새 플레이리스트
-                        </button>
+                        <Button variant="primary" size="lg" fullWidth>새 플레이리스트</Button>
                     </Link>
                 </Column1>
                 <Column2>
@@ -203,34 +205,34 @@ export default function PlaylistsView() {
                                     <p className="text-4xl font-bold">{selectedPlaylist.title}</p>
                                     <div className="flex flex-row items-center gap-2">
                                         {me && me.id === selectedPlaylist.master.id && (
-                                            <button
-                                                className="size-10 flex items-center justify-center rounded-full bg-zinc-700 hover:bg-zinc-600 text-sm cursor-pointer"
+                                            <Button
+                                                variant="icon"
                                                 onClick={() => setShowDeleteConfirm(true)}
                                                 title="플레이리스트 삭제"
                                             >
                                                 <DeleteIcon className="w-6 h-6"/>
-                                            </button>
+                                            </Button>
                                         )}
                                         {me && me.id === selectedPlaylist.master.id && (
-                                            <button
-                                                className="size-10 flex items-center justify-center rounded-full bg-zinc-700 hover:bg-zinc-600 text-sm cursor-pointer"
+                                            <Button
+                                                variant="icon"
                                                 onClick={() => {
                                                     window.location.href = `/playlists/${selectedPlaylist.id}/modify`;
                                                 }}
                                                 title="플레이리스트 수정"
                                             >
                                                 <PencilIcon className="w-5 h-5"/>
-                                            </button>
+                                            </Button>
                                         )}
-                                        <button
+                                        <Button
+                                            variant="icon"
                                             disabled={favoriteUpdating}
                                             onClick={toggleFavorite}
-                                            className={`size-10 flex items-center justify-center rounded-full transition-colors bg-zinc-700 hover:bg-zinc-600 ${favoriteUpdating ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
                                             title={selectedPlaylist.favorite ? "즐겨찾기 해제" : "즐겨찾기 추가"}
                                         >
                                             {selectedPlaylist.favorite ? <FilledStarIcon className="w-6 h-6"/> :
                                                 <StarIcon className="w-6 h-6"/>}
-                                        </button>
+                                        </Button>
                                     </div>
                                 </div>
                                 <div className="flex flex-col">
@@ -269,19 +271,17 @@ export default function PlaylistsView() {
                         <p className="text-xl font-bold mb-4">플레이리스트 삭제</p>
                         <p className="mb-4">선택한 플레이리스트를 정말로 삭제하시겠습니까?</p>
                         <div className="flex flex-row justify-end gap-2">
-                            <button
-                                onClick={() => setShowDeleteConfirm(false)}
-                                className="flex-1 bg-zinc-700 hover:bg-zinc-600 rounded-full py-2 text-center font-bold transition-colors cursor-pointer"
-                            >
+                            <Button variant="secondary" fullWidth onClick={() => setShowDeleteConfirm(false)}>
                                 취소
-                            </button>
-                            <button
+                            </Button>
+                            <Button
+                                variant="danger"
+                                fullWidth
                                 onClick={handleConfirmDelete}
-                                className={`flex-1 bg-red-600 hover:bg-red-500 rounded-full py-2 text-center font-bold transition-colors ${deleting ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
-                                disabled={deleting}
+                                loading={deleting}
                             >
-                                {deleting ? "삭제 중..." : "삭제"}
-                            </button>
+                                삭제
+                            </Button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- PlaylistWriteView의 alert Modal을 토스트(sonner)로 전환하고, alert Modal 관련 상태/JSX 제거
- PlaylistsView의 `alert()` 호출을 토스트로 전환하고, 즐겨찾기/삭제 액션에 토스트 추가
- Button 컴포넌트에 `icon` variant 추가 (`size-10 p-0 rounded-full bg-zinc-700`)
- 두 뷰의 모든 인라인 `<button>`을 Button 공통 컴포넌트로 교체
- RoomCreate의 방 생성 TODO에 토스트 주석 추가

Closes #144

## Test plan
- [x] PlaylistWriteView에서 유효성 검증 실패 시 토스트가 표시되는지 확인
- [x] 플레이리스트 저장 성공 시 토스트 표시 후 목록으로 이동하는지 확인
- [x] 플레이리스트 저장 실패 시 에러 토스트가 표시되는지 확인
- [x] PlaylistsView에서 삭제 성공/실패 시 토스트가 표시되는지 확인
- [x] 즐겨찾기 추가/해제/실패 시 각각 적절한 토스트가 표시되는지 확인
- [x] 뒤로가기 모달의 확인/취소 버튼이 Button 컴포넌트로 렌더되는지 확인
- [x] 삭제/수정/즐겨찾기 아이콘 버튼이 icon variant로 렌더되는지 확인
- [x] 삭제 확인 모달의 취소(secondary)/삭제(danger) 버튼이 올바르게 렌더되는지 확인
- [x] 브라우저 alert()이 어디에서도 호출되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)