### PR TITLE
feat: 공통 타입 및 CSS 유틸리티 추가

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -92,6 +92,14 @@
   animation: slide-down 0.2s ease-out forwards;
 }
 
+@keyframes stagger-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@utility animate-stagger-fade-in {
+  animation: stagger-fade-in 0.3s ease-out both;
+}
+
 /* 그라디언트 배경 */
 @utility bg-gradient-dark {
   background: linear-gradient(145deg, #18181b, #1a1a22);

--- a/front/app/utils/ChatMessage.ts
+++ b/front/app/utils/ChatMessage.ts
@@ -1,0 +1,19 @@
+interface ChatMessageBase {
+    timestamp: string;
+}
+
+export interface ChatMessage extends ChatMessageBase {
+    type: 'message';
+    senderId: number;
+    senderNickname: string;
+    content: string;
+}
+
+export interface SystemMessage extends ChatMessageBase {
+    type: 'system';
+    eventType: 'join' | 'leave';
+    targetNickname: string;
+}
+
+type RoomChatMessage = ChatMessage | SystemMessage;
+export default RoomChatMessage;

--- a/front/app/utils/RoomResponse.ts
+++ b/front/app/utils/RoomResponse.ts
@@ -4,6 +4,9 @@ export default interface RoomResponse {
     playlist: RoomResponsePlaylist,
     representativeTrackEmbedId: string,
     masterDisplayName: string,
+    currentPlayerCount: number,
+    maxPlayerCount: number,
+    hasPassword: boolean,
 }
 
 export interface RoomResponsePlaylist {


### PR DESCRIPTION
## Summary
- `ChatMessage.ts` 신규 생성: 일반 메시지(`ChatMessage`) / 시스템 메시지(`SystemMessage`) 유니온 타입
- `RoomResponse.ts`에 `currentPlayerCount`, `maxPlayerCount`, `hasPassword` 필드 추가
- `app.css`에 `animate-stagger-fade-in` 애니메이션 유틸리티 추가

Closes #157

## Test plan
- [x] `npm run typecheck` 통과 (CI에서 확인)
- [x] 기존 `RoomResponse` 사용처에서 빌드 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)