### PR TITLE
feat: 방 목록 카드 리디자인

### DIFF
--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -1,6 +1,6 @@
 import AppShell from "~/components/layout/AppShell";
 import SearchBar from "~/components/ui/SearchBar";
-import React, {useEffect, useState} from "react";
+import React, {useEffect, useMemo, useState} from "react";
 import { Link } from "react-router";
 import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import type RoomResponse from "~/utils/RoomResponse";
@@ -12,100 +12,142 @@ export default function RoomsView() {
     const [showCreate, setShowCreate] = useState(false);
 
     useEffect(() => {
-        setRooms(
-            [
-                {
-                    id: 1,
-                    title: "테스트 방 1",
-                    playlist: {
-                        id: 1,
-                        title: "테스트 플레이리스트 1",
-                        trackCount: 10,
-                    },
-                    representativeTrackEmbedId: "sPLqsLsooJY",
-                    masterDisplayName: "플레이어1",
-                },
-                {
-                    id: 1,
-                    title: "테스트 방 1",
-                    playlist: {
-                        id: 1,
-                        title: "테스트 플레이리스트 1",
-                        trackCount: 10,
-                    },
-                    representativeTrackEmbedId: "sPLqsLsooJY",
-                    masterDisplayName: "플레이어1",
-                },
-                {
-                    id: 1,
-                    title: "테스트 방 1",
-                    playlist: {
-                        id: 1,
-                        title: "테스트 플레이리스트 1",
-                        trackCount: 10,
-                    },
-                    representativeTrackEmbedId: "sPLqsLsooJY",
-                    masterDisplayName: "플레이어1",
-                },
-                {
-                    id: 1,
-                    title: "테스트 방 1",
-                    playlist: {
-                        id: 1,
-                        title: "테스트 플레이리스트 1",
-                        trackCount: 10,
-                    },
-                    representativeTrackEmbedId: "sPLqsLsooJY",
-                    masterDisplayName: "플레이어1",
-                },
-            ]
-        )
+        setRooms([
+            {
+                id: 1,
+                title: "K-POP 퀴즈방",
+                playlist: { id: 1, title: "내가 만든 플리", trackCount: 12 },
+                representativeTrackEmbedId: "sPLqsLsooJY",
+                masterDisplayName: "플레이어1",
+                currentPlayerCount: 3,
+                maxPlayerCount: 20,
+                hasPassword: false,
+            },
+            {
+                id: 2,
+                title: "2000년대 히트곡",
+                playlist: { id: 2, title: "올드보이", trackCount: 8 },
+                representativeTrackEmbedId: "dTAAsCNK7RA",
+                masterDisplayName: "올드보이",
+                currentPlayerCount: 7,
+                maxPlayerCount: 10,
+                hasPassword: false,
+            },
+            {
+                id: 3,
+                title: "친구들만의 방",
+                playlist: { id: 3, title: "뮤직러버", trackCount: 20 },
+                representativeTrackEmbedId: "9bZkp7q19f0",
+                masterDisplayName: "뮤직러버",
+                currentPlayerCount: 2,
+                maxPlayerCount: 5,
+                hasPassword: true,
+            },
+            {
+                id: 4,
+                title: "애니 OST 맞추기",
+                playlist: { id: 4, title: "오타쿠", trackCount: 15 },
+                representativeTrackEmbedId: "UxxajLWwzqY",
+                masterDisplayName: "오타쿠",
+                currentPlayerCount: 5,
+                maxPlayerCount: 10,
+                hasPassword: false,
+            },
+        ]);
     }, []);
+
+    const filteredRooms = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return rooms;
+        return rooms.filter(
+            (room) =>
+                room.title.toLowerCase().includes(q) ||
+                room.playlist.title.toLowerCase().includes(q) ||
+                room.masterDisplayName.toLowerCase().includes(q),
+        );
+    }, [rooms, query]);
 
     return (
         <AppShell variant="main" activeTab="rooms" title="플레이 룸">
             <ColumnsContainer>
                 <div className="pt-4 px-4 gap-4 w-full flex flex-col items-center">
                     <div className="w-full max-w-2xl">
-                        <SearchBar query={query} setQuery={setQuery}></SearchBar>
+                        <SearchBar query={query} setQuery={setQuery} />
                     </div>
                     <div className="w-full">
-                        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-                            <div className="m-2 p-4 cursor-pointer bg-zinc-800 rounded-lg flex items-center justify-center hover:bg-zinc-700 transition-colors min-h-[88px] min-w-[88px]" onClick={() => setShowCreate(true)}>
-                                <span className="text-4xl font-bold text-zinc-200">+</span>
+                        {filteredRooms.length === 0 && query.trim().length > 0 ? (
+                            <div className="flex flex-col items-center justify-center py-20 text-zinc-500">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="size-12 mb-3 text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                                </svg>
+                                <p className="text-sm font-semibold">검색 결과가 없습니다</p>
                             </div>
-                            {
-                                rooms.map((room) => (
-                                    <Link to={`/rooms/${room.id}`} key={room.id} className="m-2 p-4 bg-zinc-800 rounded-lg hover:bg-zinc-700 transition-colors">
-                                        <div className="flex flex-row items-center gap-4">
-                                            <div className="flex-shrink-0">
-                                                <img
-                                                    src={`https://img.youtube.com/vi/${room.representativeTrackEmbedId}/mqdefault.jpg`}
-                                                    className="w-20 h-20 object-cover rounded-md shadow-md"
-                                                    alt="thumbnail"
-                                                />
-                                            </div>
-                                            <div className="flex flex-col justify-center flex-1">
-                                                <h2 className="text-lg font-bold">{room.title}</h2>
-                                                <p className="text-sm text-zinc-300">
-                                                    플레이리스트: <span className="font-semibold text-zinc-200">{room.playlist.title}</span>
-                                                </p>
-                                                <p className="text-sm text-zinc-300">
-                                                    곡 수: <span className="font-semibold text-zinc-200">{room.playlist.trackCount}곡</span>
-                                                </p>
-                                                <p className="text-sm text-zinc-300">
-                                                    방장: <span className="font-semibold text-zinc-200">{room.masterDisplayName}</span>
-                                                </p>
+                        ) : filteredRooms.length === 0 && query.trim().length === 0 && rooms.length === 0 ? (
+                            <div className="flex flex-col items-center justify-center py-20 text-zinc-500">
+                                <svg xmlns="http://www.w3.org/2000/svg" className="size-12 mb-3 text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+                                </svg>
+                                <p className="text-sm font-semibold">아직 방이 없습니다</p>
+                                <p className="text-xs mt-1">새로운 방을 만들어보세요</p>
+                            </div>
+                        ) : (
+                            <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+                                {/* 방 생성 카드 */}
+                                <div
+                                    className="border-2 border-dashed border-border rounded-xl flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-neon-cyan/40 hover:bg-neon-cyan/[0.03] transition-all duration-300 min-h-[160px] animate-stagger-fade-in"
+                                    onClick={() => setShowCreate(true)}
+                                >
+                                    <div className="size-10 rounded-xl bg-neon-cyan/10 flex items-center justify-center">
+                                        <span className="text-xl font-bold text-neon-cyan">+</span>
+                                    </div>
+                                    <span className="text-sm text-zinc-400">방 만들기</span>
+                                </div>
+                                {/* 방 카드 목록 */}
+                                {filteredRooms.map((room, index) => (
+                                    <Link
+                                        to={`/rooms/${room.id}`}
+                                        key={room.id}
+                                        className="bg-gradient-dark border border-border rounded-xl overflow-hidden hover:border-neon-cyan/40 hover:shadow-glow-cyan hover:-translate-y-0.5 transition-all duration-300 animate-stagger-fade-in"
+                                        style={{ animationDelay: `${(index + 1) * 50}ms` }}
+                                    >
+                                        {/* 썸네일 */}
+                                        <div className="relative h-[100px] overflow-hidden">
+                                            <img
+                                                src={`https://img.youtube.com/vi/${room.representativeTrackEmbedId}/mqdefault.jpg`}
+                                                className="w-full h-full object-cover"
+                                                alt="thumbnail"
+                                            />
+                                            <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-[#18181b] to-transparent" />
+                                            {/* 뱃지 오버레이 */}
+                                            <div className="absolute top-2 right-2 flex gap-1.5">
+                                                {room.hasPassword && (
+                                                    <div className="bg-black/60 backdrop-blur-md px-2 py-0.5 rounded-md text-[0.65rem] text-zinc-400 flex items-center">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" className="size-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                                            <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+                                                        </svg>
+                                                    </div>
+                                                )}
+                                                <div className="bg-black/60 backdrop-blur-md px-2 py-0.5 rounded-md text-[0.65rem] text-zinc-400 flex items-center gap-1">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" className="size-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                                        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+                                                    </svg>
+                                                    {room.currentPlayerCount}/{room.maxPlayerCount}
+                                                </div>
                                             </div>
                                         </div>
+                                        {/* 카드 정보 */}
+                                        <div className="p-3">
+                                            <div className="text-sm font-semibold text-zinc-200 mb-1 truncate">{room.title}</div>
+                                            <div className="text-xs text-zinc-500 truncate">{room.playlist.title} · {room.playlist.trackCount}곡</div>
+                                        </div>
                                     </Link>
-                                ))
-                            }
-                        </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </div>
             </ColumnsContainer>
             {showCreate && <RoomCreate onClose={() => setShowCreate(false)} />}
         </AppShell>
-      );
+    );
 }


### PR DESCRIPTION
## Summary
- 방 카드를 세로 레이아웃(썸네일 상단 + 정보 하단)으로 전환하고 네온 글로우 테마 적용
- 참여 인원 뱃지, 잠금 아이콘, stagger 애니메이션, 빈 상태 디자인 추가
- 검색 필터링 (방 이름, 플레이리스트, 플레이어 이름)으로 클라이언트 사이드 필터 구현

Closes #158

## Test plan
- [x] 방 카드가 세로 레이아웃(썸네일 + 정보)으로 표시되는지 확인
- [x] 호버 시 cyan 글로우 보더 + translateY 효과 확인
- [x] 참여 인원 뱃지 (3/20 형식) 표시 확인
- [x] 비밀번호 방에 자물쇠 아이콘 표시 확인
- [x] 방 생성 카드 dashed 보더 + 호버 효과 확인
- [x] 카드 stagger fade-in 애니메이션 확인
- [x] 반응형: 모바일 2열, lg 3열, xl 4열 확인
- [x] 방 없을 때 "아직 방이 없습니다" 빈 상태 확인
- [x] 검색어 입력 시 필터링 및 "검색 결과가 없습니다" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)