### PR TITLE
feat: 방 생성 모달 네온 스타일 적용

### DIFF
--- a/front/app/components/ui/RoomCreate.tsx
+++ b/front/app/components/ui/RoomCreate.tsx
@@ -143,7 +143,7 @@ export default function RoomCreate({isOpen, onClose}: RoomCreateProps) {
 
     return (
         <Modal isOpen={isOpen} onClose={onClose}>
-            <div className="w-full max-w-md">
+            <div className="w-[28rem] max-w-full">
                 <div className="text-xl font-bold mb-6 text-center text-zinc-100">방 만들기</div>
                 <form className="flex flex-col gap-5">
                     {/* 플레이리스트 선택 */}
@@ -296,6 +296,7 @@ export default function RoomCreate({isOpen, onClose}: RoomCreateProps) {
                     {/* 버튼 */}
                     <div className="flex gap-2 mt-2">
                         <Button
+                            type="button"
                             variant="primary"
                             size="lg"
                             fullWidth
@@ -309,6 +310,7 @@ export default function RoomCreate({isOpen, onClose}: RoomCreateProps) {
                             만들기
                         </Button>
                         <Button
+                            type="button"
                             variant="secondary"
                             size="lg"
                             fullWidth

--- a/front/app/components/ui/RoomCreate.tsx
+++ b/front/app/components/ui/RoomCreate.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from "react";
 import {fetchFavoritePlaylists, fetchMyPlaylists, searchPlaylistsByTitle} from "~/utils/api";
 import Button from "~/components/ui/Button";
 import Dropdown from "~/components/ui/Dropdown";
+import Modal from "~/components/ui/Modal";
 
 interface PlaylistOption {
     value: number;
@@ -9,12 +10,13 @@ interface PlaylistOption {
 }
 
 interface RoomCreateProps {
+    isOpen: boolean;
     onClose: () => void;
 }
 
 const MAX_ROOM_CAPACITY = 20;
 
-export default function RoomCreate({onClose}: RoomCreateProps) {
+export default function RoomCreate({isOpen, onClose}: RoomCreateProps) {
     const [roomName, setRoomName] = useState("");
     const [selectedRoomCapacity, setSelectedRoomCapacity] = useState(1);
     const [usePassword, setUsePassword] = useState(false);
@@ -140,11 +142,8 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
     }, [usePassword]);
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-            {/* 배경 오버레이 */}
-            <div className="absolute inset-0 bg-black opacity-60"/>
-            {/* 모달 내용 */}
-            <div className="relative bg-zinc-900 rounded-xl p-6 w-full max-w-md shadow-2xl border border-zinc-800">
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <div className="w-full max-w-md">
                 <div className="text-xl font-bold mb-6 text-center text-zinc-100">방 만들기</div>
                 <form className="flex flex-col gap-5">
                     {/* 플레이리스트 선택 */}
@@ -320,6 +319,6 @@ export default function RoomCreate({onClose}: RoomCreateProps) {
                     </div>
                 </form>
             </div>
-        </div>
+        </Modal>
     );
 }

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -147,7 +147,7 @@ export default function RoomsView() {
                     </div>
                 </div>
             </ColumnsContainer>
-            {showCreate && <RoomCreate onClose={() => setShowCreate(false)} />}
+            <RoomCreate isOpen={showCreate} onClose={() => setShowCreate(false)} />
         </AppShell>
     );
 }


### PR DESCRIPTION
## Summary
- `RoomCreate` 컴포넌트의 자체 오버레이(`fixed inset-0`, `bg-black opacity-60`) 제거
- 공통 `Modal` 컴포넌트로 래핑하여 글로우 보더(`shadow-glow-cyan`), 백드롭 블러(`backdrop-blur-sm`), 열림/닫힘 애니메이션 적용
- props 인터페이스 변경: `{ onClose }` → `{ isOpen, onClose }`
- `RoomsView.tsx` 호출부를 조건부 렌더링에서 `isOpen` prop 전달 방식으로 변경

Closes #160

## Test plan
- [x] 방 만들기 버튼 클릭 시 모달이 글로우 보더 + 백드롭 블러와 함께 열리는지 확인
- [x] 모달 열림/닫힘 애니메이션(scale-in/out, fade-in/out)이 동작하는지 확인
- [x] 모달 외부 클릭 시 닫히는지 확인
- [x] 기존 폼 기능(플레이리스트 검색, 방 이름, 인원수, 비밀번호) 정상 동작 확인
- [x] 취소 버튼 클릭 시 모달이 닫히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)