### PR TITLE
feat: 플레이리스트 상세 뷰 히어로 리디자인 및 즐겨찾기 애니메이션

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -92,6 +92,15 @@
   animation: slide-down 0.2s ease-out forwards;
 }
 
+@keyframes pulse-star {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+@utility animate-pulse-star {
+  animation: pulse-star 0.3s ease-out;
+}
+
 @keyframes stagger-fade-in {
   from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -216,12 +216,12 @@ export default function PlaylistsView() {
                 </Column1>
                 <Column2>
                     {selectedPlaylist !== null && (
-                        <div className="w-full h-full flex flex-col justify-center p-4 gap-4">
+                        <div className="w-full md:h-full flex flex-col md:justify-center p-4 gap-4">
                             {/* 히어로 영역 */}
                             <div className="flex flex-col md:flex-row gap-4">
                                 <img
                                     src={`https://img.youtube.com/vi/${selectedPlaylist.representativeTrack.embedId}/hq720.jpg`}
-                                    className="w-full md:w-[120px] md:h-[120px] aspect-square object-cover rounded-xl border border-border shadow-[0_4px_20px_rgba(0,0,0,0.3)] shrink-0"
+                                    className="size-32 md:size-[120px] object-cover rounded-xl border border-border shadow-[0_4px_20px_rgba(0,0,0,0.3)] shrink-0 mx-auto md:mx-0"
                                     alt="thumbnail"
                                 />
                                 <div className="flex flex-col gap-2 min-w-0">

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -216,7 +216,7 @@ export default function PlaylistsView() {
                 </Column1>
                 <Column2>
                     {selectedPlaylist !== null && (
-                        <div className="w-full h-full flex flex-col p-4 gap-4 overflow-y-auto">
+                        <div className="w-full flex flex-col p-4 gap-4">
                             {/* 히어로 영역 */}
                             <div className="flex flex-col md:flex-row gap-4">
                                 <img

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -216,7 +216,7 @@ export default function PlaylistsView() {
                 </Column1>
                 <Column2>
                     {selectedPlaylist !== null && (
-                        <div className="w-full flex flex-col p-4 gap-4">
+                        <div className="w-full h-full flex flex-col justify-center p-4 gap-4">
                             {/* 히어로 영역 */}
                             <div className="flex flex-col md:flex-row gap-4">
                                 <img

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -44,6 +44,7 @@ export default function PlaylistsView() {
     const me = useMeStore(state => state.me);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [favoriteKey, setFavoriteKey] = useState(0);
 
     useEffect(() => {
         if (selectedPlaylistId === null) {
@@ -97,6 +98,7 @@ export default function PlaylistsView() {
         const playlistId = selectedPlaylist.id;
         const optimistic = {...selectedPlaylist, favorite: !selectedPlaylist.favorite} as PlaylistResponse;
         setSelectedPlaylist(optimistic);
+        setFavoriteKey(prev => prev + 1);
         try {
             if (optimistic.favorite) {
                 await favoritePlaylist(playlistId);
@@ -213,70 +215,66 @@ export default function PlaylistsView() {
                     </Link>
                 </Column1>
                 <Column2>
-                    {
-                        selectedPlaylist !== null &&
-                        <div className="w-full h-full flex flex-col justify-center p-4">
-                            <div className="w-full flex flex-col bg-zinc-800 text-zinc-200 rounded-2xl p-8 gap-4">
-                                <div className="flex flex-row justify-between items-center">
-                                    <p className="text-4xl font-bold">{selectedPlaylist.title}</p>
-                                    <div className="flex flex-row items-center gap-2">
-                                        {me && me.id === selectedPlaylist.master.id && (
-                                            <Button
-                                                variant="icon"
-                                                onClick={() => setShowDeleteConfirm(true)}
-                                                title="플레이리스트 삭제"
-                                            >
-                                                <DeleteIcon className="w-6 h-6"/>
-                                            </Button>
-                                        )}
-                                        {me && me.id === selectedPlaylist.master.id && (
-                                            <Button
-                                                variant="icon"
-                                                onClick={() => {
-                                                    window.location.href = `/playlists/${selectedPlaylist.id}/modify`;
-                                                }}
-                                                title="플레이리스트 수정"
-                                            >
-                                                <PencilIcon className="w-5 h-5"/>
-                                            </Button>
-                                        )}
+                    {selectedPlaylist !== null && (
+                        <div className="w-full h-full flex flex-col p-4 gap-4 overflow-y-auto">
+                            {/* 히어로 영역 */}
+                            <div className="flex flex-col md:flex-row gap-4">
+                                <img
+                                    src={`https://img.youtube.com/vi/${selectedPlaylist.representativeTrack.embedId}/hq720.jpg`}
+                                    className="w-full md:w-[120px] md:h-[120px] aspect-square object-cover rounded-xl border border-border shadow-[0_4px_20px_rgba(0,0,0,0.3)] shrink-0"
+                                    alt="thumbnail"
+                                />
+                                <div className="flex flex-col gap-2 min-w-0">
+                                    <p className="text-xl font-extrabold text-zinc-200">{selectedPlaylist.title}</p>
+                                    <div className="flex flex-col text-xs text-zinc-500 leading-relaxed">
+                                        <p><UserIcon className="inline-block size-4 mr-1"/>{selectedPlaylist.master.displayName}</p>
+                                        <p><SongIcon className="inline-block size-4 mr-1"/>{selectedPlaylist.trackCount}곡 (약 {Math.round(selectedPlaylist.expectedPlayTimeSec / 60)}분)</p>
+                                    </div>
+                                    <p className="text-sm text-zinc-400 line-clamp-3">{selectedPlaylist.description}</p>
+                                    <div className="flex flex-row items-center gap-2 mt-1">
                                         <Button
                                             variant="icon"
                                             disabled={favoriteUpdating}
                                             onClick={toggleFavorite}
                                             title={selectedPlaylist.favorite ? "즐겨찾기 해제" : "즐겨찾기 추가"}
                                         >
-                                            {selectedPlaylist.favorite ? <FilledStarIcon className="w-6 h-6"/> :
-                                                <StarIcon className="w-6 h-6"/>}
+                                            <span key={favoriteKey} className="animate-pulse-star">
+                                                {selectedPlaylist.favorite
+                                                    ? <FilledStarIcon className="w-6 h-6"/>
+                                                    : <StarIcon className="w-6 h-6"/>}
+                                            </span>
                                         </Button>
+                                        {me && me.id === selectedPlaylist.master.id && (
+                                            <>
+                                                <Button
+                                                    variant="icon"
+                                                    onClick={() => {
+                                                        window.location.href = `/playlists/${selectedPlaylist.id}/modify`;
+                                                    }}
+                                                    title="플레이리스트 수정"
+                                                >
+                                                    <PencilIcon className="w-5 h-5"/>
+                                                </Button>
+                                                <Button
+                                                    variant="icon"
+                                                    onClick={() => setShowDeleteConfirm(true)}
+                                                    title="플레이리스트 삭제"
+                                                >
+                                                    <DeleteIcon className="w-6 h-6"/>
+                                                </Button>
+                                            </>
+                                        )}
                                     </div>
                                 </div>
-                                <div className="flex flex-col">
-                                    <p><UserIcon className="inline-block"/>{selectedPlaylist.master.displayName}</p>
-                                    <p><SongIcon className="inline-block"/>{selectedPlaylist.trackCount}곡
-                                        (약 {Math.round(selectedPlaylist.expectedPlayTimeSec / 60)}분)</p>
-                                </div>
-                                <div className="flex flex-col">
-                                    <p className="text-3xl font-bold">소개</p>
-                                    <p>{selectedPlaylist.description}</p>
-                                </div>
-                                <div className="flex flex-col">
-                                    <p className="text-3xl font-bold">대표곡 미리 듣기</p>
-                                    <MusicPlayer embedId={selectedPlaylist.representativeTrack.embedId}
-                                                 startTimeSec={selectedPlaylist.representativeTrack.startTimeSec}
-                                                 endTimeSec={selectedPlaylist.representativeTrack.endTimeSec}></MusicPlayer>
-                                </div>
-                                <div className="flex flex-col items-center">
-                                    <img
-                                        src={`https://img.youtube.com/vi/${selectedPlaylist.representativeTrack.embedId}/hq720.jpg`}
-                                        className="size-64 object-cover"
-                                        alt="tumbnail"
-                                    >
-                                    </img>
-                                </div>
                             </div>
+                            {/* 뮤직 플레이어 */}
+                            <MusicPlayer
+                                embedId={selectedPlaylist.representativeTrack.embedId}
+                                startTimeSec={selectedPlaylist.representativeTrack.startTimeSec}
+                                endTimeSec={selectedPlaylist.representativeTrack.endTimeSec}
+                            />
                         </div>
-                    }
+                    )}
                 </Column2>
             </ColumnsContainer>
             {/* 삭제 확인 모달 */}


### PR DESCRIPTION
## Summary
- 히어로 영역을 가로 배치로 재구성 (120x120 썸네일 + 제목/메타/설명/액션 버튼)
- 모바일에서 세로 배치로 자동 전환 (`flex-col md:flex-row`)
- 기존 별도 "소개" 섹션과 하단 큰 썸네일을 히어로 내 통합
- 즐겨찾기 토글 시 별 아이콘 pulse 애니메이션 추가 (`animate-pulse-star`)
- `app.css`에 `pulse-star` 키프레임 + 유틸리티 추가

Closes #164

## Test plan
- [x] 플레이리스트 선택 시 히어로 영역에 썸네일/제목/메타/설명이 가로 배치되는지 확인
- [x] 모바일에서 히어로가 세로 배치로 전환되는지 확인
- [x] 즐겨찾기 토글 시 별 아이콘에 pulse 효과가 재생되는지 확인
- [x] 소유자일 때 수정/삭제 버튼이 표시되는지 확인
- [x] MusicPlayer가 히어로 영역 아래에 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)