### PR TITLE
feat: MusicPlayer 리디자인 — 그라디언트 프로그레스 바, 곡 정보, 시간 표시

### DIFF
--- a/front/app/components/layout/NavigationItem.tsx
+++ b/front/app/components/layout/NavigationItem.tsx
@@ -16,7 +16,7 @@ export default function NavigationItem({
 }: NavigationItemProperties) {
     return <div
         onClick={onClick}
-        className={`relative w-[56px] flex flex-col items-center justify-center gap-1 py-2 rounded-lg transition-all duration-200 ${
+        className={`relative w-[72px] flex flex-col items-center justify-center gap-1 py-2 rounded-lg transition-all duration-200 ${
             clicked
                 ? "bg-[rgba(34,211,238,0.1)] shadow-glow-cyan"
                 : "cursor-pointer hover:bg-zinc-800/50"
@@ -29,7 +29,7 @@ export default function NavigationItem({
         React.cloneElement(icon, {
             className: `size-[24px] ${clicked ? "fill-neon-cyan text-neon-cyan drop-shadow-[0_0_8px_rgba(34,211,238,0.5)]" : ""}`,
         })}
-        <span className={`text-[10px] leading-tight ${clicked ? "text-neon-cyan" : "text-zinc-400"}`}>
+        <span className={`text-xs leading-tight ${clicked ? "text-neon-cyan" : "text-zinc-400"}`}>
             {title as string}
         </span>
     </div>

--- a/front/app/components/ui/MusicPlayer.tsx
+++ b/front/app/components/ui/MusicPlayer.tsx
@@ -7,13 +7,22 @@ interface MusicPlayerProps {
     embedId: string,
     startTimeSec: number,
     endTimeSec: number,
+    title?: string,
 }
 
-export default function MusicPlayer({ embedId, startTimeSec, endTimeSec }: MusicPlayerProps) {
+function formatTime(sec: number): string {
+    const minutes = Math.floor(sec / 60);
+    const seconds = Math.floor(sec % 60);
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export default function MusicPlayer({ embedId, startTimeSec, endTimeSec, title }: MusicPlayerProps) {
     const [isPlaying, setIsPlaying] = useState(false);
     const [progress, setProgress] = useState(0);
+    const [currentTimeSec, setCurrentTimeSec] = useState(0);
     const playerRef = useRef<any>(null);
     const animationFrameRef = useRef<number | null>(null);
+    const totalDuration = endTimeSec - startTimeSec;
 
     // 유튜브 플레이어가 로드될 때 실행
     const onReady = (event: any) => {
@@ -61,6 +70,8 @@ export default function MusicPlayer({ embedId, startTimeSec, endTimeSec }: Music
         }
 
         const currentTime = playerRef.current.getCurrentTime();
+        const elapsed = currentTime - startTimeSec;
+        setCurrentTimeSec(Math.max(0, elapsed));
         setProgress(((currentTime - startTimeSec) / (endTimeSec - startTimeSec)) * 100);
 
         animationFrameRef.current = requestAnimationFrame(updateProgress);
@@ -87,12 +98,22 @@ export default function MusicPlayer({ embedId, startTimeSec, endTimeSec }: Music
 
     return (
         <>
-            <div className="w-full border border-border rounded-xl p-3 flex flex-row items-center gap-2">
-                <button className="size-16 cursor-pointer hover:text-neon-cyan hover:drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] transition-all duration-200" onClick={togglePlay}>
-                    { isPlaying ? <PauseIcon className="size-16"/> : <PlayIcon  className="size-16"/> }
-                </button>
-                <div className="w-full h-2 bg-muted rounded-full">
-                    <div className="h-2 bg-neon-cyan shadow-glow-cyan rounded-full" style={{ width: `${progress}%` }}></div>
+            <div className="w-full border border-border rounded-xl p-3 flex flex-col gap-2">
+                <div className="flex flex-row items-center gap-3">
+                    <button className="text-neon-cyan drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] cursor-pointer hover:drop-shadow-[0_0_12px_rgba(34,211,238,0.6)] transition-all duration-200" onClick={togglePlay}>
+                        { isPlaying ? <PauseIcon className="size-8"/> : <PlayIcon className="size-8"/> }
+                    </button>
+                    <div className="flex-1 flex flex-col gap-1">
+                        {title && (
+                            <span className="text-xs font-semibold text-zinc-200">{title}</span>
+                        )}
+                        <div className="w-full h-[3px] bg-muted rounded-full">
+                            <div className="h-[3px] bg-gradient-to-r from-neon-cyan to-neon-purple shadow-[0_0_8px_rgba(34,211,238,0.5)] rounded-full" style={{ width: `${progress}%` }}></div>
+                        </div>
+                        <div className="flex justify-end">
+                            <span className="text-xs text-zinc-500">{formatTime(currentTimeSec)} / {formatTime(totalDuration)}</span>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div className="hidden">

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -144,7 +144,7 @@ export default function PlaylistsView() {
                         {tabLabels.map((label, idx) => (
                             <button
                                 key={tabTypes[idx]}
-                                className={`flex-1 px-3 py-1.5 rounded-md text-xs font-semibold transition-all duration-200 cursor-pointer ${
+                                className={`flex-1 px-3 py-1.5 rounded-md text-sm font-semibold transition-all duration-200 cursor-pointer ${
                                     selectedTab === tabTypes[idx]
                                         ? "bg-neon-cyan/15 text-neon-cyan"
                                         : "text-zinc-500 hover:text-zinc-300"
@@ -203,8 +203,8 @@ export default function PlaylistsView() {
                                         alt="thumbnail"
                                     />
                                     <div className="flex flex-col justify-center min-w-0">
-                                        <p className="text-sm font-semibold text-zinc-200 truncate">{playlist.title}</p>
-                                        <p className="text-xs text-zinc-500">{playlist.master.displayName}</p>
+                                        <p className="text-base font-semibold text-zinc-200 truncate">{playlist.title}</p>
+                                        <p className="text-sm text-zinc-500">{playlist.master.displayName}</p>
                                     </div>
                                 </div>
                             )
@@ -225,12 +225,12 @@ export default function PlaylistsView() {
                                     alt="thumbnail"
                                 />
                                 <div className="flex flex-col gap-2 min-w-0">
-                                    <p className="text-xl font-extrabold text-zinc-200">{selectedPlaylist.title}</p>
-                                    <div className="flex flex-col text-xs text-zinc-500 leading-relaxed">
+                                    <p className="text-2xl font-extrabold text-zinc-200">{selectedPlaylist.title}</p>
+                                    <div className="flex flex-col text-sm text-zinc-500 leading-relaxed">
                                         <p><UserIcon className="inline-block size-4 mr-1"/>{selectedPlaylist.master.displayName}</p>
                                         <p><SongIcon className="inline-block size-4 mr-1"/>{selectedPlaylist.trackCount}곡 (약 {Math.round(selectedPlaylist.expectedPlayTimeSec / 60)}분)</p>
                                     </div>
-                                    <p className="text-sm text-zinc-400 line-clamp-3">{selectedPlaylist.description}</p>
+                                    <p className="text-base text-zinc-400 line-clamp-3">{selectedPlaylist.description}</p>
                                     <div className="flex flex-row items-center gap-2 mt-1">
                                         <Button
                                             variant="icon"

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -272,6 +272,7 @@ export default function PlaylistsView() {
                                 embedId={selectedPlaylist.representativeTrack.embedId}
                                 startTimeSec={selectedPlaylist.representativeTrack.startTimeSec}
                                 endTimeSec={selectedPlaylist.representativeTrack.endTimeSec}
+                                title={selectedPlaylist.title}
                             />
                         </div>
                     )}


### PR DESCRIPTION
## Summary
- 프로그레스 바를 cyan→purple 그라디언트로 변경하고 높이를 `h-[3px]`으로 조정
- 재생 버튼을 `size-8`로 축소하고 cyan 글로우 상시 적용
- `title` prop 추가하여 곡 정보(플레이리스트 제목) 표시
- `formatTime` 유틸 함수로 현재/총 시간 표시 (`M:SS` 형식)
- `PlaylistsView`에서 MusicPlayer에 `title` prop 전달

Closes #165

## Test plan
- [x] 플레이리스트 상세에서 MusicPlayer에 플레이리스트 제목이 표시되는지 확인
- [x] 프로그레스 바가 cyan→purple 그라디언트로 표시되는지 확인
- [x] 재생 버튼에 cyan 글로우가 적용되는지 확인
- [x] 현재 시간 / 총 시간이 `M:SS` 형식으로 표시되는지 확인
- [x] 재생/일시정지 시 시간이 정상 업데이트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)