### PR TITLE
feat: 로그인 페이지 랜딩 스타일 개편

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -109,6 +109,15 @@
   animation: stagger-fade-in 0.3s ease-out both;
 }
 
+@keyframes float {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(30px, -20px); }
+}
+@keyframes float-reverse {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-20px, 30px); }
+}
+
 /* 그라디언트 배경 */
 @utility bg-gradient-dark {
   background: linear-gradient(145deg, #18181b, #1a1a22);

--- a/front/app/routes/LoginView.tsx
+++ b/front/app/routes/LoginView.tsx
@@ -7,23 +7,65 @@ export default function LoginView() {
     const redirectUrl = redirectUrlString ? new URL(redirectUrlString) : null
 
     if (redirectUrl && redirectUrl.origin !== window.location.origin) {
-        return <div className="w-full h-full flex flex-col justify-center items-center gap-24">
-            <p className="text-5xl font-bold">로그인</p>
-            <p className="text-3xl">진입 경로가 잘못되었습니다.</p>
-    </div>
+        return (
+            <div className="relative w-full h-full flex items-center justify-center overflow-hidden bg-background">
+                <NeonBackground />
+                <div className="relative z-10 text-center">
+                    <h1 className="text-6xl font-black tracking-tight bg-gradient-to-r from-neon-cyan via-neon-purple to-neon-pink bg-clip-text text-transparent mb-4"
+                        style={{ textShadow: "0 0 40px rgba(34, 211, 238, 0.3)" }}>
+                        NOMAT
+                    </h1>
+                    <p className="text-xl text-zinc-400">진입 경로가 잘못되었습니다.</p>
+                </div>
+            </div>
+        )
     }
 
-    return <div className="w-full h-full flex flex-col justify-center items-center gap-24">
-        <p className="text-5xl font-bold">로그인</p>
-        <div className="flex flex-row">
-            <button
-                className="size-24 rounded-full bg-[#5865f2] cursor-pointer"
-                onClick={() => goToDiscordLogin(redirectUrl)}
-            >
-                <DiscordIcon className="size-16 mx-4 my-4"></DiscordIcon>
-            </button>
+    return (
+        <div className="relative w-full h-full flex items-center justify-center overflow-hidden bg-background">
+            <NeonBackground />
+            <div className="relative z-10 text-center flex flex-col items-center">
+                <h1 className="text-7xl font-black tracking-tight bg-gradient-to-r from-neon-cyan via-neon-purple to-neon-pink bg-clip-text text-transparent mb-2"
+                    style={{ textShadow: "0 0 40px rgba(34, 211, 238, 0.3)" }}>
+                    NOMAT
+                </h1>
+                <p className="text-zinc-500 text-base mb-10">
+                    친구들과 함께하는 노래 맞추기 게임
+                </p>
+                <button
+                    className="inline-flex items-center gap-3 px-8 py-3.5 bg-[#5865f2] rounded-[14px] text-white font-bold text-base cursor-pointer transition-all duration-300 hover:-translate-y-0.5"
+                    style={{ boxShadow: "0 0 20px rgba(88, 101, 242, 0.3)" }}
+                    onMouseEnter={(e) => { e.currentTarget.style.boxShadow = "0 0 35px rgba(88, 101, 242, 0.5)" }}
+                    onMouseLeave={(e) => { e.currentTarget.style.boxShadow = "0 0 20px rgba(88, 101, 242, 0.3)" }}
+                    onClick={() => goToDiscordLogin(redirectUrl)}
+                >
+                    <DiscordIcon className="size-6" />
+                    Discord로 시작하기
+                </button>
+            </div>
         </div>
-    </div>
+    )
+}
+
+function NeonBackground() {
+    return (
+        <div className="absolute inset-0 overflow-hidden">
+            <div
+                className="absolute w-[400px] h-[400px] -top-[100px] -left-[50px]"
+                style={{
+                    background: "radial-gradient(circle, rgba(34, 211, 238, 0.12), transparent 60%)",
+                    animation: "float 6s ease-in-out infinite",
+                }}
+            />
+            <div
+                className="absolute w-[300px] h-[300px] -bottom-[80px] -right-[50px]"
+                style={{
+                    background: "radial-gradient(circle, rgba(167, 139, 250, 0.1), transparent 60%)",
+                    animation: "float-reverse 8s ease-in-out infinite",
+                }}
+            />
+        </div>
+    )
 }
 
 function goToDiscordLogin(redirectUrl: URL | null) {
@@ -37,5 +79,4 @@ function goToDiscordLogin(redirectUrl: URL | null) {
             }
           }, 500);
     }
-    
 }


### PR DESCRIPTION
## Summary
- NOMAT 그라디언트 로고 (cyan → purple → pink) 및 서브타이틀 추가
- 네온 원형 그라디언트 배경 애니메이션 (float/float-reverse keyframes)
- Discord 버튼 리디자인: 아이콘 + 텍스트, 글로우 shadow, hover 효과
- 잘못된 진입 경로 에러 UI도 네온 스타일로 통일

Closes #170

## Test plan
- [x] `/login` 접근 시 NOMAT 그라디언트 로고, 서브타이틀, 네온 배경 애니메이션 표시 확인
- [x] Discord 버튼 hover 시 글로우 강화 + translateY(-2px) 동작 확인
- [x] Discord 버튼 클릭 시 OAuth2 로그인 플로우 정상 동작 확인
- [x] `?redirectUrl=` 파라미터로 잘못된 origin 전달 시 네온 스타일 에러 메시지 표시 확인
- [x] 배경 그라디언트 float 애니메이션이 부드럽게 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)