### PR TITLE
feat: 에러 페이지 한국어화 & 네온 디자인

### DIFF
--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -48,30 +48,98 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "Oops!";
-  let details = "An unexpected error occurred.";
+  let code = "";
+  let message = "문제가 발생했습니다";
+  let details = "알 수 없는 오류가 발생했습니다.";
   let stack: string | undefined;
+  let isNotFound = false;
+  let isRouteError = false;
 
   if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error";
-    details =
-      error.status === 404
-        ? "The requested page could not be found."
-        : error.statusText || details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
-    details = error.message;
-    stack = error.stack;
+    isRouteError = true;
+    code = String(error.status);
+    if (error.status === 404) {
+      isNotFound = true;
+      message = "페이지를 찾을 수 없습니다";
+      details = "요청하신 페이지가 존재하지 않거나 이동되었습니다.";
+    } else {
+      message = "오류가 발생했습니다";
+      details = error.statusText || `서버에서 ${error.status} 오류가 반환되었습니다.`;
+    }
+  } else if (error instanceof Error) {
+    if (import.meta.env.DEV) {
+      details = error.message;
+      stack = error.stack;
+    }
   }
 
   return (
-    <main className="pt-16 p-4 container mx-auto">
-      <h1>{message}</h1>
-      <p>{details}</p>
-      {stack && (
-        <pre className="w-full p-4 overflow-x-auto">
-          <code>{stack}</code>
-        </pre>
-      )}
+    <main className="relative w-full h-full flex items-center justify-center overflow-hidden bg-background">
+      <div className="absolute inset-0 overflow-hidden">
+        <div
+          className="absolute w-[400px] h-[400px] -top-[100px] -left-[50px]"
+          style={{
+            background:
+              "radial-gradient(circle, rgba(34, 211, 238, 0.12), transparent 60%)",
+            animation: "float 6s ease-in-out infinite",
+          }}
+        />
+        <div
+          className="absolute w-[300px] h-[300px] -bottom-[80px] -right-[50px]"
+          style={{
+            background:
+              "radial-gradient(circle, rgba(167, 139, 250, 0.1), transparent 60%)",
+            animation: "float-reverse 8s ease-in-out infinite",
+          }}
+        />
+      </div>
+
+      <div className="relative z-10 text-center flex flex-col items-center px-4">
+        {code && (
+          <p
+            className="text-8xl font-black tracking-tight bg-gradient-to-r from-neon-cyan via-neon-purple to-neon-pink bg-clip-text text-transparent mb-4"
+            style={{ textShadow: "0 0 40px rgba(34, 211, 238, 0.3)" }}
+          >
+            {code}
+          </p>
+        )}
+        <h1 className="text-2xl font-bold text-zinc-100 mb-2">{message}</h1>
+        <p className="text-zinc-400 mb-8 max-w-md">{details}</p>
+
+        <div className="flex gap-3">
+          {isNotFound ? (
+            <a
+              href="/"
+              className="inline-flex items-center px-6 py-2.5 rounded-xl bg-neon-cyan/10 text-neon-cyan font-semibold text-sm border border-neon-cyan/20 transition-all duration-300 hover:-translate-y-0.5 hover:bg-neon-cyan/15"
+              style={{ boxShadow: "0 0 15px rgba(34, 211, 238, 0.15)" }}
+            >
+              홈으로 돌아가기
+            </a>
+          ) : (
+            <button
+              onClick={() => window.location.reload()}
+              className="inline-flex items-center px-6 py-2.5 rounded-xl bg-neon-cyan/10 text-neon-cyan font-semibold text-sm border border-neon-cyan/20 cursor-pointer transition-all duration-300 hover:-translate-y-0.5 hover:bg-neon-cyan/15"
+              style={{ boxShadow: "0 0 15px rgba(34, 211, 238, 0.15)" }}
+            >
+              다시 시도
+            </button>
+          )}
+          {isRouteError && !isNotFound && (
+            <a
+              href="/"
+              className="inline-flex items-center px-6 py-2.5 rounded-xl bg-zinc-800 text-zinc-300 font-semibold text-sm border border-zinc-700 transition-all duration-300 hover:-translate-y-0.5 hover:bg-zinc-700"
+            >
+              홈으로 돌아가기
+            </a>
+          )}
+        </div>
+
+        {stack && (
+          <pre className="mt-8 w-full max-w-2xl p-4 rounded-xl bg-zinc-900/80 border border-zinc-800 text-left text-xs text-zinc-400 overflow-x-auto">
+            <code>{stack}</code>
+          </pre>
+        )}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- `root.tsx`의 ErrorBoundary를 한국어 메시지 + 네온 디자인으로 전면 교체
- 404 분기: "페이지를 찾을 수 없습니다" + 홈으로 돌아가기 버튼
- 기타 HTTP 에러 분기: "오류가 발생했습니다" + 상태 코드 그라디언트 텍스트 + 재시도/홈 버튼
- 네트워크/런타임 에러 분기: "문제가 발생했습니다" + 재시도 버튼
- DEV 모드 스택 트레이스 유지 (네온 스타일 적용)
- 에러 코드를 cyan→purple→pink 그라디언트 대형 텍스트로 표시
- 네온 원형 그라디언트 배경 + floating 애니메이션 적용

Closes #171

## Test plan
- [x] 존재하지 않는 URL 접근 시 한국어 404 페이지가 네온 디자인으로 표시된다
- [x] 404 페이지에서 "홈으로 돌아가기" 클릭 시 홈으로 이동한다
- [x] 에러 상태에서 "다시 시도" 클릭 시 페이지가 새로고침된다
- [x] DEV 모드에서 에러 스택 트레이스가 표시된다
- [x] 에러 코드(404, 500 등)가 큰 그라디언트 텍스트로 표시된다

🤖 Generated with [Claude Code](https://claude.com/claude-code)