### PR TITLE
feat: 곡 편집 모달 & 생성/수정 페이지 네온 스타일 통일

### DIFF
--- a/front/app/components/ui/TrackEditLayer.tsx
+++ b/front/app/components/ui/TrackEditLayer.tsx
@@ -159,12 +159,14 @@ export default function TrackCreateLayer(props: TrackEditLayerProps) {
 				<div className="p-2 flex justify-center">
 					{ getEmbedIdByUrl(youTubeUrl) ?
 						<YouTube videoId={getEmbedIdByUrl(youTubeUrl) ?? ""} opts={youTubeOptions} onReady={onYouTubeReady}></YouTube>
-						: <div className="w-80 h-45 bg-black"></div>
+						: <div className="w-80 h-45 bg-zinc-900 rounded-lg border border-border flex items-center justify-center">
+							<p className="text-zinc-500 text-sm">YouTube URL을 입력해주세요</p>
+						  </div>
 					}
 				</div>
 				<div className="flex flex-col gap-2 w-full md:w-2xl">
-					<div className="flex flex-col px-4 gap-1">
-						<p className="px-4">YouTube URL</p>
+					<div className="flex flex-col gap-2">
+						<p className="text-sm font-medium text-zinc-300">YouTube URL</p>
 						<div className="flex-1 h-10 p-2 shrink bg-surface border border-border text-zinc-200 rounded-full focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
 							<input
 								type="text"
@@ -175,10 +177,10 @@ export default function TrackCreateLayer(props: TrackEditLayerProps) {
 								className="w-full pl-[8px] placeholder-zinc-500 focus:outline-none"
 							/>
 						</div>
-						<p className="px-4 text-xs text-red-600 h-2">{isValidYoutubeUrl() ? " " : "올바른 URL을 입력해 주세요."}</p>
+						<p className="text-xs text-red-600 h-2">{isValidYoutubeUrl() ? " " : "올바른 URL을 입력해 주세요."}</p>
 					</div>
-					<div className="flex flex-col px-4 gap-1">
-						<p className="px-4">제목</p>
+					<div className="flex flex-col gap-2">
+						<p className="text-sm font-medium text-zinc-300">제목</p>
 						<div className="flex-1 h-10 p-2 shrink bg-surface border border-border text-zinc-200 rounded-full focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
 							<input
 								type="text"
@@ -189,29 +191,29 @@ export default function TrackCreateLayer(props: TrackEditLayerProps) {
 								className="w-full pl-[8px] placeholder-zinc-500 focus:outline-none"
 							/>
 						</div>
-						<p className="px-4 text-xs text-red-600 h-2">{isValidTitle() ? " " : "제목을 입력해 주세요."}</p>
+						<p className="text-xs text-red-600 h-2">{isValidTitle() ? " " : "제목을 입력해 주세요."}</p>
 					</div>
-					<div className="flex flex-col px-4 gap-1">
-						<p className="px-4">재생 시간</p>
+					<div className="flex flex-col gap-2">
+						<p className="text-sm font-medium text-zinc-300">재생 시간</p>
 						<div className="flex flex-row items-center gap-2">
 							<TimePicker timeSec={startTimeSec} setTimeSec={setStartTimeSec}></TimePicker>
 							<p>-</p>
 							<TimePicker timeSec={endTimeSec} setTimeSec={setEndTimeSec}></TimePicker>
 						</div>
-						<p className="px-4 text-xs text-red-600 h-2">{isValidPlayTime() ? " " : "재생 시간이 올바르지 않습니다."}</p>
+						<p className="text-xs text-red-600 h-2">{isValidPlayTime() ? " " : "재생 시간이 올바르지 않습니다."}</p>
 					</div>
-					<div className="flex flex-col px-4 gap-1">
-						<p className="px-4">반복 횟수</p>
+					<div className="flex flex-col gap-2">
+						<p className="text-sm font-medium text-zinc-300">반복 횟수</p>
 						<div className="flex-1">
 							<Dropdown values={["1", "2", "3", "4", "5"]} selectedValue={repeatCount} setValue={setRepeatCount} ></Dropdown>
 						</div>
-						<p className="px-4 text-xs text-red-600 h-2"></p>
+						<p className="text-xs text-red-600 h-2"></p>
 					</div>
-					<div className="flex flex-col px-4 gap-1">
-						<p className="px-4">추가 정답 <span>({additionalTitles.length}/{maxAdditoinalTitlesCount})</span></p>
+					<div className="flex flex-col gap-2">
+						<p className="text-sm font-medium text-zinc-300">추가 정답 <span>({additionalTitles.length}/{maxAdditoinalTitlesCount})</span></p>
 						<AdditionalTitleEditor maxAdditionalTitlesCount={maxAdditoinalTitlesCount} additionalTitles={additionalTitles} setAdditionalTitles={setAdditionalTitles}></AdditionalTitleEditor>
 					</div>
-					<div className="flex-1 flex flex-row gap-1 flex-wrap text-nowrap px-4 py-1">
+					<div className="flex-1 flex flex-row gap-1 flex-wrap text-nowrap py-1">
 						{
 							additionalTitles.map((title, index) =>
 								<button key={index} className="flex flex-row items-center bg-zinc-600 rounded-full px-3 gap-1 overflow-hidden">

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -163,7 +163,6 @@ export default function PlaylistWriteView() {
 					<p className="hidden md:block text-4xl font-bold p-4">새 플레이리스트</p>
 					<div className="flex flex-col px-6 gap-2">
 						<p className="text-2xl font-bold">썸네일</p>
-						<p className="px-2 text-zinc-400">썸네일은 대표곡 기준으로 표시됩니다.</p>
 						<div className="mx-auto w-full max-w-48 md:max-w-96 aspect-square">
 							{
 								representativeIndex !== null ?

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -215,7 +215,7 @@ export default function PlaylistWriteView() {
 					<div className="w-full flex-1 px-4 py-2">
 						<div className="w-full h-full p-8 bg-zinc-800 text-zinc-200 rounded-2xl flex flex-col gap-2">
 							<div
-								className="px-auto py-6 border-1 text-6xl font-bold text-center hover:bg-zinc-700 rounded-lg cursor-pointer"
+								className="px-auto py-6 border-1 text-6xl font-bold text-center hover:bg-neon-cyan/5 transition-all duration-200 rounded-lg cursor-pointer"
 								onClick={() => {
 									setSelectedTrack(null)
 									setSelectedTrackIndex(null)
@@ -223,9 +223,12 @@ export default function PlaylistWriteView() {
 								}}
 							>+
 							</div>
+							{tracks.length === 0 && (
+								<p className="text-zinc-500 text-center py-8">곡을 추가해보세요</p>
+							)}
 							{
 								tracks.map((track: Track, index: number) => (
-									<div className="flex flex-row items-center p-2 hover:bg-zinc-700 rounded-lg cursor-pointer gap-4"
+									<div className="flex flex-row items-center p-2 hover:bg-neon-cyan/5 transition-all duration-200 rounded-lg cursor-pointer gap-4"
 										 onClick={() => {
 											 setSelectedTrack(track)
 											 setSelectedTrackIndex(index)

--- a/front/app/routes/PlaylistWriteView.tsx
+++ b/front/app/routes/PlaylistWriteView.tsx
@@ -1,7 +1,6 @@
 import { useParams } from "react-router";
 import AppShell from "~/components/layout/AppShell";
 import SaveIcon from "~/assets/save.svg?react";
-import QuestionMarkSquareIcon from "~/assets/question-mark-squre.svg?react";
 import DeleteIcon from "~/assets/delete.svg?react";
 import StarIcon from "~/assets/star.svg?react";
 import FilledStarIcon from "~/assets/filled-star.svg?react";
@@ -169,7 +168,9 @@ export default function PlaylistWriteView() {
 							{
 								representativeIndex !== null ?
 									<img className="w-full h-full object-contain rounded-2xl" src={`https://img.youtube.com/vi/${tracks[representativeIndex].embedId}/maxresdefault.jpg`} alt={tracks[representativeIndex].title} draggable={false}/>
-									: <QuestionMarkSquareIcon className="w-full h-full"></QuestionMarkSquareIcon>
+									: <div className="w-full h-full bg-zinc-900 rounded-2xl border border-border flex items-center justify-center">
+										<p className="text-zinc-500 text-sm">대표곡을 선택하면 썸네일이 표시됩니다</p>
+									  </div>
 							}
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
- TrackEditLayer 빈 YouTube 영역을 `bg-zinc-900` + 안내 텍스트로 개선
- TrackEditLayer 입력 폼 라벨을 `text-sm font-medium text-zinc-300`으로 통일, `gap-1` → `gap-2`
- PlaylistWriteView 곡 목록 빈 상태 UI 추가 ("곡을 추가해보세요")
- PlaylistWriteView 곡 목록 항목 및 "+" 버튼 hover를 `hover:bg-neon-cyan/5`로 통일

Closes #166

## Test plan
- [x] 곡 편집 모달에서 YouTube URL 미입력 시 빈 영역이 `bg-zinc-900` + 안내 텍스트로 표시되는지 확인
- [x] 곡 편집 모달의 라벨 스타일이 통일되었는지 확인
- [x] 플레이리스트 생성/수정 페이지에서 곡이 없을 때 빈 상태 메시지가 표시되는지 확인
- [x] "+" 버튼과 곡 목록 항목 hover 시 네온 cyan 스타일이 적용되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)