### PR TITLE
feat: 스켈레톤 UI 컴포넌트 & 로딩 상태 적용

### DIFF
--- a/front/app/components/ui/Skeleton.tsx
+++ b/front/app/components/ui/Skeleton.tsx
@@ -1,0 +1,29 @@
+function Skeleton({ className = "" }: { className?: string }) {
+    return <div className={`animate-pulse bg-zinc-700/50 rounded-lg ${className}`} />;
+}
+
+export function RoomCardSkeleton() {
+    return (
+        <div className="bg-gradient-dark border border-border rounded-xl overflow-hidden">
+            <Skeleton className="h-[100px] rounded-none" />
+            <div className="p-3 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+            </div>
+        </div>
+    );
+}
+
+export function PlaylistItemSkeleton() {
+    return (
+        <div className="flex flex-row p-2.5 px-3 gap-3">
+            <Skeleton className="size-10 shrink-0" />
+            <div className="flex flex-col justify-center gap-1.5 min-w-0 flex-1">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3.5 w-1/2" />
+            </div>
+        </div>
+    );
+}
+
+export default Skeleton;

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -28,6 +28,7 @@ import DeleteIcon from "~/assets/delete.svg?react";
 import useMeStore from "~/stores/MeStore";
 import { toast } from "sonner";
 import Button from "~/components/ui/Button";
+import { PlaylistItemSkeleton } from "~/components/ui/Skeleton";
 
 export default function PlaylistsView() {
     const searchTypes = ["제목", "제작자"];
@@ -45,6 +46,7 @@ export default function PlaylistsView() {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [deleting, setDeleting] = useState(false);
     const [favoriteKey, setFavoriteKey] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         if (selectedPlaylistId === null) {
@@ -56,27 +58,26 @@ export default function PlaylistsView() {
     }, [selectedPlaylistId])
 
     useEffect(() => {
+        setIsLoading(true);
+        let request: Promise<PlaylistMetaDataResponse[]>;
         if (selectedTab === "all") {
             if (debouncedQuery.length > 0) {
                 if (selectedSearchType === "제작자") {
-                    fetchByMasterDisplayName(debouncedQuery)
-                        .then(playlists => setPlaylists(playlists));
-                    return;
-                } else if (selectedSearchType === "제목") {
-                    searchPlaylistsByTitle(debouncedQuery)
-                        .then(playlists => setPlaylists(playlists));
+                    request = fetchByMasterDisplayName(debouncedQuery);
+                } else {
+                    request = searchPlaylistsByTitle(debouncedQuery);
                 }
             } else {
-                fetchRecentlyAddedPlaylists()
-                    .then(playlists => setPlaylists(playlists));
+                request = fetchRecentlyAddedPlaylists();
             }
         } else if (selectedTab === "favorite") {
-            fetchFavoritePlaylists()
-                .then(playlists => setPlaylists(playlists));
-        } else if (selectedTab === "mine") {
-            fetchMyPlaylists()
-                .then(playlists => setPlaylists(playlists));
+            request = fetchFavoritePlaylists();
+        } else {
+            request = fetchMyPlaylists();
         }
+        request
+            .then(playlists => setPlaylists(playlists))
+            .finally(() => setIsLoading(false));
     }, [selectedTab, selectedSearchType, debouncedQuery]);
 
     // 검색어 디바운스
@@ -178,7 +179,11 @@ export default function PlaylistsView() {
                         </div>
                     )}
                     <div className="flex flex-col grow py-2 overflow-y-auto">
-                        {playlists.length === 0 ? (
+                        {isLoading ? (
+                            Array.from({ length: 5 }).map((_, i) => (
+                                <PlaylistItemSkeleton key={i} />
+                            ))
+                        ) : playlists.length === 0 ? (
                             <div className="flex-1 flex flex-col items-center justify-center gap-4 text-zinc-500 py-8">
                                 <p>아직 플레이리스트가 없습니다</p>
                                 <Link to="/playlists/create">

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -155,7 +155,7 @@ export default function RoomsView() {
                                     </Link>
                                 ))}
                             </div>
-                        ))}
+                        )}
                     </div>
                 </div>
             </ColumnsContainer>

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -5,13 +5,16 @@ import { Link } from "react-router";
 import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import type RoomResponse from "~/utils/RoomResponse";
 import RoomCreate from "~/components/ui/RoomCreate";
+import { RoomCardSkeleton } from "~/components/ui/Skeleton";
 
 export default function RoomsView() {
     const [query, setQuery] = useState("");
     const [rooms, setRooms] = useState<Array<RoomResponse>>([]);
     const [showCreate, setShowCreate] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
+        const timer = setTimeout(() => {
         setRooms([
             {
                 id: 1,
@@ -54,6 +57,9 @@ export default function RoomsView() {
                 hasPassword: false,
             },
         ]);
+        setIsLoading(false);
+        }, 500);
+        return () => clearTimeout(timer);
     }, []);
 
     const filteredRooms = useMemo(() => {
@@ -75,7 +81,13 @@ export default function RoomsView() {
                         <SearchBar query={query} setQuery={setQuery} />
                     </div>
                     <div className="w-full">
-                        {filteredRooms.length === 0 && query.trim().length > 0 ? (
+                        {isLoading ? (
+                            <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+                                {Array.from({ length: 8 }).map((_, i) => (
+                                    <RoomCardSkeleton key={i} />
+                                ))}
+                            </div>
+                        ) : filteredRooms.length === 0 && query.trim().length > 0 ? (
                             <div className="flex flex-col items-center justify-center py-20 text-zinc-500">
                                 <svg xmlns="http://www.w3.org/2000/svg" className="size-12 mb-3 text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                                     <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
@@ -143,7 +155,7 @@ export default function RoomsView() {
                                     </Link>
                                 ))}
                             </div>
-                        )}
+                        ))}
                     </div>
                 </div>
             </ColumnsContainer>


### PR DESCRIPTION
## Summary
- `Skeleton.tsx` 신규 생성: 기본 `Skeleton`, `RoomCardSkeleton`, `PlaylistItemSkeleton` 컴포넌트
- `RoomsView.tsx`: `isLoading` 상태 + `setTimeout(500ms)` 로딩 시뮬레이션 + 스켈레톤 8개 그리드 표시
- `PlaylistsView.tsx`: `isLoading` 상태 + API 호출 연동 (`.finally()`로 로딩 해제) + 스켈레톤 5개 표시

Closes #172

## Test plan
- [x] RoomsView 진입 시 500ms간 카드형 스켈레톤이 pulse 애니메이션으로 표시된 후 방 목록으로 전환되는지 확인
- [x] PlaylistsView에서 탭 전환 시 리스트형 스켈레톤이 표시된 후 결과로 전환되는지 확인
- [x] PlaylistsView에서 검색어 입력 시 스켈레톤이 표시된 후 검색 결과로 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)