### PR TITLE
feat: 버튼 클릭 피드백 & 스크롤 등장 애니메이션

### DIFF
--- a/front/app/app.css
+++ b/front/app/app.css
@@ -101,13 +101,6 @@
   animation: pulse-star 0.3s ease-out;
 }
 
-@keyframes stagger-fade-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-@utility animate-stagger-fade-in {
-  animation: stagger-fade-in 0.3s ease-out both;
-}
 
 @keyframes float {
   0%, 100% { transform: translate(0, 0); }

--- a/front/app/components/ui/Button.tsx
+++ b/front/app/components/ui/Button.tsx
@@ -46,7 +46,7 @@ export default function Button({
             disabled={isDisabled}
             className={`
                 inline-flex items-center justify-center font-medium
-                transition-all duration-200 cursor-pointer
+                transition-all duration-200 cursor-pointer active:scale-[0.98]
                 ${variantStyles[variant]}
                 ${variant !== "icon" ? sizeStyles[size] : ""}
                 ${fullWidth ? "w-full" : ""}

--- a/front/app/components/ui/ScrollReveal.tsx
+++ b/front/app/components/ui/ScrollReveal.tsx
@@ -1,0 +1,42 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+interface ScrollRevealProps {
+    children: ReactNode;
+    delay?: number;
+    className?: string;
+}
+
+export default function ScrollReveal({ children, delay = 0, className = "" }: ScrollRevealProps) {
+    const ref = useRef<HTMLDivElement>(null);
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setIsVisible(true);
+                    observer.unobserve(el);
+                }
+            },
+            { threshold: 0.1 },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    return (
+        <div
+            ref={ref}
+            className={`transition-all duration-300 ${
+                isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+            } ${className}`}
+            style={{ transitionDelay: `${delay}ms` }}
+        >
+            {children}
+        </div>
+    );
+}

--- a/front/app/routes/PlaylistsView.tsx
+++ b/front/app/routes/PlaylistsView.tsx
@@ -29,6 +29,7 @@ import useMeStore from "~/stores/MeStore";
 import { toast } from "sonner";
 import Button from "~/components/ui/Button";
 import { PlaylistItemSkeleton } from "~/components/ui/Skeleton";
+import ScrollReveal from "~/components/ui/ScrollReveal";
 
 export default function PlaylistsView() {
     const searchTypes = ["제목", "제작자"];
@@ -191,27 +192,28 @@ export default function PlaylistsView() {
                                 </Link>
                             </div>
                         ) : (
-                            playlists.map((playlist) =>
-                                <div
-                                    key={playlist.id}
-                                    id={playlist.id.toString()}
-                                    className={`flex flex-row p-2.5 px-3 gap-3 rounded-lg transition-all duration-200 cursor-pointer hover:bg-neon-cyan/5 ${
-                                        selectedPlaylistId === playlist.id
-                                            ? "bg-neon-cyan/8 border border-neon-cyan/15"
-                                            : "border border-transparent"
-                                    }`}
-                                    onClick={clickPlaylist}
-                                >
-                                    <img
-                                        src={`https://img.youtube.com/vi/${playlist.representativeTrack.embedId}/mqdefault.jpg`}
-                                        className="size-10 rounded-lg object-cover"
-                                        alt="thumbnail"
-                                    />
-                                    <div className="flex flex-col justify-center min-w-0">
-                                        <p className="text-base font-semibold text-zinc-200 truncate">{playlist.title}</p>
-                                        <p className="text-sm text-zinc-500">{playlist.master.displayName}</p>
+                            playlists.map((playlist, index) =>
+                                <ScrollReveal key={playlist.id} delay={index * 50}>
+                                    <div
+                                        id={playlist.id.toString()}
+                                        className={`flex flex-row p-2.5 px-3 gap-3 rounded-lg transition-all duration-200 cursor-pointer hover:bg-neon-cyan/5 ${
+                                            selectedPlaylistId === playlist.id
+                                                ? "bg-neon-cyan/8 border border-neon-cyan/15"
+                                                : "border border-transparent"
+                                        }`}
+                                        onClick={clickPlaylist}
+                                    >
+                                        <img
+                                            src={`https://img.youtube.com/vi/${playlist.representativeTrack.embedId}/mqdefault.jpg`}
+                                            className="size-10 rounded-lg object-cover"
+                                            alt="thumbnail"
+                                        />
+                                        <div className="flex flex-col justify-center min-w-0">
+                                            <p className="text-base font-semibold text-zinc-200 truncate">{playlist.title}</p>
+                                            <p className="text-sm text-zinc-500">{playlist.master.displayName}</p>
+                                        </div>
                                     </div>
-                                </div>
+                                </ScrollReveal>
                             )
                         )}
                     </div>

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -6,6 +6,7 @@ import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import type RoomResponse from "~/utils/RoomResponse";
 import RoomCreate from "~/components/ui/RoomCreate";
 import { RoomCardSkeleton } from "~/components/ui/Skeleton";
+import ScrollReveal from "~/components/ui/ScrollReveal";
 
 export default function RoomsView() {
     const [query, setQuery] = useState("");
@@ -105,23 +106,24 @@ export default function RoomsView() {
                         ) : (
                             <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
                                 {/* 방 생성 카드 */}
-                                <div
-                                    className="border-2 border-dashed border-border rounded-xl flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-neon-cyan/40 hover:bg-neon-cyan/[0.03] transition-all duration-300 min-h-[160px] animate-stagger-fade-in"
-                                    onClick={() => setShowCreate(true)}
-                                >
-                                    <div className="size-10 rounded-xl bg-neon-cyan/10 flex items-center justify-center">
-                                        <span className="text-xl font-bold text-neon-cyan">+</span>
+                                <ScrollReveal>
+                                    <div
+                                        className="border-2 border-dashed border-border rounded-xl flex flex-col items-center justify-center gap-2 cursor-pointer hover:border-neon-cyan/40 hover:bg-neon-cyan/[0.03] transition-all duration-300 min-h-[160px]"
+                                        onClick={() => setShowCreate(true)}
+                                    >
+                                        <div className="size-10 rounded-xl bg-neon-cyan/10 flex items-center justify-center">
+                                            <span className="text-xl font-bold text-neon-cyan">+</span>
+                                        </div>
+                                        <span className="text-sm text-zinc-400">방 만들기</span>
                                     </div>
-                                    <span className="text-sm text-zinc-400">방 만들기</span>
-                                </div>
+                                </ScrollReveal>
                                 {/* 방 카드 목록 */}
                                 {filteredRooms.map((room, index) => (
-                                    <Link
-                                        to={`/rooms/${room.id}`}
-                                        key={room.id}
-                                        className="bg-gradient-dark border border-border rounded-xl overflow-hidden hover:border-neon-cyan/40 hover:shadow-glow-cyan hover:-translate-y-0.5 transition-all duration-300 animate-stagger-fade-in"
-                                        style={{ animationDelay: `${(index + 1) * 50}ms` }}
-                                    >
+                                    <ScrollReveal key={room.id} delay={(index + 1) * 50}>
+                                        <Link
+                                            to={`/rooms/${room.id}`}
+                                            className="block bg-gradient-dark border border-border rounded-xl overflow-hidden hover:border-neon-cyan/40 hover:shadow-glow-cyan hover:-translate-y-0.5 transition-all duration-300"
+                                        >
                                         {/* 썸네일 */}
                                         <div className="relative h-[100px] overflow-hidden">
                                             <img
@@ -152,7 +154,8 @@ export default function RoomsView() {
                                             <div className="text-sm font-semibold text-zinc-200 mb-1 truncate">{room.title}</div>
                                             <div className="text-xs text-zinc-500 truncate">{room.playlist.title} · {room.playlist.trackCount}곡</div>
                                         </div>
-                                    </Link>
+                                        </Link>
+                                    </ScrollReveal>
                                 ))}
                             </div>
                         )}


### PR DESCRIPTION
## Summary
- Button 컴포넌트에 `active:scale-[0.98]` 클릭 피드백 추가
- IntersectionObserver 기반 `ScrollReveal` 컴포넌트 신규 생성 (threshold 0.1, delay prop, 한 번 등장 후 unobserve)
- RoomsView 방 카드의 `animate-stagger-fade-in`을 `ScrollReveal`로 교체
- PlaylistsView 리스트 아이템에 `ScrollReveal` 순차 등장 적용
- 미사용 `stagger-fade-in` CSS 키프레임/유틸리티 제거

Closes #174

## Test plan
- [x] 모든 Button 클릭 시 scale(0.98) 피드백이 체감되는지 확인
- [x] 방 카드가 스크롤 시 fade-in-up으로 순차 등장하는지 확인
- [x] 플레이리스트 아이템이 스크롤 시 fade-in-up으로 순차 등장하는지 확인
- [x] 한 번 등장한 요소가 다시 스크롤해도 애니메이션이 반복되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)