### PR TITLE
feat: STOMP 연결 인프라 & 방 입장 흐름 구현

### DIFF
--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/web/StompErrorHandler.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/web/StompErrorHandler.kt
@@ -1,0 +1,31 @@
+package ilpak.nomat.infrastructure.web
+
+import ilpak.nomat.common.exception.AbstractNomatException
+import org.springframework.messaging.Message
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler
+
+@Component
+class StompErrorHandler : StompSubProtocolErrorHandler() {
+
+    override fun handleClientMessageProcessingError(
+        clientMessage: Message<ByteArray>?,
+        ex: Throwable,
+    ): Message<ByteArray>? {
+        val cause = findNomatException(ex)
+        return if (cause != null) {
+            super.handleClientMessageProcessingError(clientMessage, cause)
+        } else {
+            super.handleClientMessageProcessingError(clientMessage, ex)
+        }
+    }
+
+    private fun findNomatException(ex: Throwable): AbstractNomatException? {
+        var current: Throwable? = ex
+        while (current != null) {
+            if (current is AbstractNomatException) return current
+            current = current.cause
+        }
+        return null
+    }
+}

--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/web/WebSocketConfiguration.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/web/WebSocketConfiguration.kt
@@ -14,6 +14,7 @@ import org.springframework.web.socket.server.HandshakeInterceptor
 class WebSocketConfiguration(
     private val jwtHandshakeInterceptor: HandshakeInterceptor,
     private val roomJoinChannelInterceptor: RoomJoinChannelInterceptor,
+    private val stompErrorHandler: StompErrorHandler,
     @Value("\${app.cors.origins}") private val origins: String,
 ) : WebSocketMessageBrokerConfigurer {
 
@@ -21,6 +22,7 @@ class WebSocketConfiguration(
         registry.addEndpoint("/ws")
             .setAllowedOrigins(origins)
             .addInterceptors(jwtHandshakeInterceptor)
+        registry.setErrorHandler(stompErrorHandler)
     }
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {

--- a/front/app/components/ui/PasswordModal.tsx
+++ b/front/app/components/ui/PasswordModal.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import Modal from "~/components/ui/Modal";
+
+interface PasswordModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (password: string) => void;
+    isLoading: boolean;
+    error: string | null;
+}
+
+export default function PasswordModal({ isOpen, onClose, onSubmit, isLoading, error }: PasswordModalProps) {
+    const [password, setPassword] = useState("");
+
+    function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (password.trim() && !isLoading) {
+            onSubmit(password);
+        }
+    }
+
+    function handleClose() {
+        if (!isLoading) {
+            setPassword("");
+            onClose();
+        }
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose}>
+            <form onSubmit={handleSubmit} className="w-72">
+                <h3 className="text-lg font-bold text-zinc-100 mb-4">비밀번호 입력</h3>
+                <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="비밀번호를 입력하세요"
+                    className="w-full px-3 py-2 bg-zinc-800 border border-border rounded-lg text-sm text-zinc-200 placeholder-zinc-500 focus:outline-none focus:border-neon-cyan/50 mb-2"
+                    autoFocus
+                    disabled={isLoading}
+                />
+                {error && (
+                    <p className="text-xs text-red-400 mb-2">{error}</p>
+                )}
+                <div className="flex gap-2 mt-4">
+                    <button
+                        type="button"
+                        onClick={handleClose}
+                        disabled={isLoading}
+                        className="flex-1 px-4 py-2 text-sm text-zinc-400 bg-zinc-800 border border-border rounded-lg hover:bg-zinc-700 transition-colors disabled:opacity-50"
+                    >
+                        취소
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={!password.trim() || isLoading}
+                        className="flex-1 px-4 py-2 text-sm font-semibold text-zinc-900 bg-neon-cyan rounded-lg hover:bg-neon-cyan/80 transition-colors disabled:opacity-50"
+                    >
+                        {isLoading ? "연결 중..." : "입장"}
+                    </button>
+                </div>
+            </form>
+        </Modal>
+    );
+}

--- a/front/app/routes/RoomsView.tsx
+++ b/front/app/routes/RoomsView.tsx
@@ -1,18 +1,30 @@
 import AppShell from "~/components/layout/AppShell";
 import SearchBar from "~/components/ui/SearchBar";
 import React, {useEffect, useMemo, useState} from "react";
-import { Link } from "react-router";
+import { useNavigate } from "react-router";
 import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import type RoomResponse from "~/utils/RoomResponse";
 import RoomCreate from "~/components/ui/RoomCreate";
+import PasswordModal from "~/components/ui/PasswordModal";
 import { RoomCardSkeleton } from "~/components/ui/Skeleton";
 import ScrollReveal from "~/components/ui/ScrollReveal";
+import { connectToRoom } from "~/utils/stomp";
+import useRoomConnectionStore from "~/stores/RoomConnectionStore";
+import { toast } from "sonner";
 
 export default function RoomsView() {
+    const navigate = useNavigate();
+    const setConnection = useRoomConnectionStore((s) => s.setConnection);
+
     const [query, setQuery] = useState("");
     const [rooms, setRooms] = useState<Array<RoomResponse>>([]);
     const [showCreate, setShowCreate] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
+    const [connectingRoomId, setConnectingRoomId] = useState<number | null>(null);
+
+    const [passwordModal, setPasswordModal] = useState<{ isOpen: boolean; roomId: number | null }>({ isOpen: false, roomId: null });
+    const [passwordLoading, setPasswordLoading] = useState(false);
+    const [passwordError, setPasswordError] = useState<string | null>(null);
 
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -74,6 +86,49 @@ export default function RoomsView() {
         );
     }, [rooms, query]);
 
+    async function handleRoomClick(room: RoomResponse) {
+        if (connectingRoomId !== null) return;
+
+        if (room.hasPassword) {
+            setPasswordModal({ isOpen: true, roomId: room.id });
+            setPasswordError(null);
+            return;
+        }
+
+        setConnectingRoomId(room.id);
+        try {
+            const client = await connectToRoom(room.id);
+            setConnection(client, room.id);
+            navigate(`/rooms/${room.id}`);
+        } catch (error) {
+            toast.error(String(error));
+        } finally {
+            setConnectingRoomId(null);
+        }
+    }
+
+    async function handlePasswordSubmit(password: string) {
+        if (!passwordModal.roomId) return;
+
+        setPasswordLoading(true);
+        setPasswordError(null);
+        try {
+            const client = await connectToRoom(passwordModal.roomId, password);
+            setConnection(client, passwordModal.roomId);
+            setPasswordModal({ isOpen: false, roomId: null });
+            navigate(`/rooms/${passwordModal.roomId}`);
+        } catch (error) {
+            setPasswordError(String(error));
+        } finally {
+            setPasswordLoading(false);
+        }
+    }
+
+    function handlePasswordClose() {
+        setPasswordModal({ isOpen: false, roomId: null });
+        setPasswordError(null);
+    }
+
     return (
         <AppShell variant="main" activeTab="rooms" title="플레이 룸">
             <ColumnsContainer>
@@ -120,9 +175,13 @@ export default function RoomsView() {
                                 {/* 방 카드 목록 */}
                                 {filteredRooms.map((room, index) => (
                                     <ScrollReveal key={room.id} delay={(index + 1) * 50}>
-                                        <Link
-                                            to={`/rooms/${room.id}`}
-                                            className="block bg-gradient-dark border border-border rounded-xl overflow-hidden hover:border-neon-cyan/40 hover:shadow-glow-cyan hover:-translate-y-0.5 transition-all duration-300"
+                                        <div
+                                            onClick={() => handleRoomClick(room)}
+                                            className={`block bg-gradient-dark border border-border rounded-xl overflow-hidden transition-all duration-300 ${
+                                                connectingRoomId === room.id
+                                                    ? "opacity-70 pointer-events-none"
+                                                    : "cursor-pointer hover:border-neon-cyan/40 hover:shadow-glow-cyan hover:-translate-y-0.5"
+                                            }`}
                                         >
                                         {/* 썸네일 */}
                                         <div className="relative h-[100px] overflow-hidden">
@@ -132,6 +191,12 @@ export default function RoomsView() {
                                                 alt="thumbnail"
                                             />
                                             <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-[#18181b] to-transparent" />
+                                            {/* 로딩 오버레이 */}
+                                            {connectingRoomId === room.id && (
+                                                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                                                    <div className="size-6 border-2 border-neon-cyan border-t-transparent rounded-full animate-spin" />
+                                                </div>
+                                            )}
                                             {/* 뱃지 오버레이 */}
                                             <div className="absolute top-2 right-2 flex gap-1.5">
                                                 {room.hasPassword && (
@@ -154,7 +219,7 @@ export default function RoomsView() {
                                             <div className="text-sm font-semibold text-zinc-200 mb-1 truncate">{room.title}</div>
                                             <div className="text-xs text-zinc-500 truncate">{room.playlist.title} · {room.playlist.trackCount}곡</div>
                                         </div>
-                                        </Link>
+                                        </div>
                                     </ScrollReveal>
                                 ))}
                             </div>
@@ -163,6 +228,13 @@ export default function RoomsView() {
                 </div>
             </ColumnsContainer>
             <RoomCreate isOpen={showCreate} onClose={() => setShowCreate(false)} />
+            <PasswordModal
+                isOpen={passwordModal.isOpen}
+                onClose={handlePasswordClose}
+                onSubmit={handlePasswordSubmit}
+                isLoading={passwordLoading}
+                error={passwordError}
+            />
         </AppShell>
     );
 }

--- a/front/app/stores/RoomConnectionStore.ts
+++ b/front/app/stores/RoomConnectionStore.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import type { Client } from "@stomp/stompjs";
+
+interface RoomConnectionState {
+    client: Client | null;
+    roomId: number | null;
+    setConnection: (client: Client, roomId: number) => void;
+    clear: () => void;
+}
+
+export default create<RoomConnectionState>()((set) => ({
+    client: null,
+    roomId: null,
+    setConnection: (client, roomId) => set({ client, roomId }),
+    clear: () => set({ client: null, roomId: null }),
+}));

--- a/front/app/utils/stomp.ts
+++ b/front/app/utils/stomp.ts
@@ -1,0 +1,46 @@
+import { Client } from "@stomp/stompjs";
+
+const CONNECT_TIMEOUT_MS = 5000;
+
+function getWsUrl(): string {
+    const baseUrl = import.meta.env.VITE_SERVER_BASE_URL as string;
+    return baseUrl.replace(/^http/, "ws") + "/ws";
+}
+
+export function connectToRoom(roomId: number, password?: string): Promise<Client> {
+    return new Promise((resolve, reject) => {
+        const client = new Client({
+            brokerURL: getWsUrl(),
+            connectHeaders: {
+                roomId: String(roomId),
+                ...(password != null && { password }),
+            },
+            reconnectDelay: 0,
+        });
+
+        const timeout = setTimeout(() => {
+            client.deactivate();
+            reject("연결 시간이 초과되었습니다.");
+        }, CONNECT_TIMEOUT_MS);
+
+        client.onConnect = () => {
+            clearTimeout(timeout);
+            resolve(client);
+        };
+
+        client.onStompError = (frame) => {
+            clearTimeout(timeout);
+            const message = frame.headers["message"] || "방 입장에 실패했습니다.";
+            client.deactivate();
+            reject(message);
+        };
+
+        client.onWebSocketError = () => {
+            clearTimeout(timeout);
+            client.deactivate();
+            reject("서버에 연결할 수 없습니다.");
+        };
+
+        client.activate();
+    });
+}

--- a/front/package.json
+++ b/front/package.json
@@ -18,6 +18,7 @@
     "react-router": "^7.2.0",
     "framer-motion": "^12.4.7",
     "react-youtube": "^10.1.0",
+    "@stomp/stompjs": "^7.1.0",
     "sonner": "^2.0.0",
     "zustand": "^5.0.3"
   },


### PR DESCRIPTION
## Summary
- `@stomp/stompjs` 의존성 추가
- `connectToRoom(roomId, password?)` STOMP 연결 유틸리티 구현 (타임아웃 5초, 에러 메시지 파싱)
- `RoomConnectionStore` Zustand store — 연결된 Client + roomId 보관
- `PasswordModal` — 비밀번호 방 입장용 모달 (에러 인라인 표시, 로딩 상태)
- `RoomsView` — `<Link>` → 클릭 핸들러로 변경, 연결 성공 시에만 navigate

Closes #189

## Test plan
- [ ] 비밀번호 없는 방 카드 클릭 → 로딩 스피너 표시 → STOMP 연결 성공 시 `/rooms/{roomId}` 이동
- [ ] 비밀번호 있는 방 카드 클릭 → PasswordModal 표시 → 비밀번호 입력 후 연결 성공 시 이동
- [ ] 잘못된 비밀번호 입력 시 모달에 에러 메시지 인라인 표시
- [ ] 서버 연결 실패 시 toast.error() 표시, 페이지 유지
- [ ] 연결 중 다른 방 카드 클릭 방지 (connectingRoomId 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)