### PR TITLE
feat: RoomView WebSocket 구독 & 초기 상태 로드

### DIFF
--- a/front/app/hooks/useRoomSubscription.ts
+++ b/front/app/hooks/useRoomSubscription.ts
@@ -1,0 +1,79 @@
+import { useEffect, useCallback, useState } from "react";
+import { useNavigate } from "react-router";
+import useRoomConnectionStore from "~/stores/RoomConnectionStore";
+import { fetchRoomDetail } from "~/utils/api";
+import type RoomDetailResponse from "~/utils/RoomDetailResponse";
+import type { RoomMemberResponse } from "~/utils/RoomDetailResponse";
+import type { SystemMessage } from "~/utils/ChatMessage";
+
+interface RoomEventMessage {
+    type: "JOINED" | "LEFT";
+    roomId: number;
+    playerId: number;
+    nickname: string;
+}
+
+interface UseRoomSubscriptionResult {
+    roomDetail: RoomDetailResponse | null;
+    players: RoomMemberResponse[];
+    systemMessages: SystemMessage[];
+    isLoading: boolean;
+}
+
+export default function useRoomSubscription(roomId: number): UseRoomSubscriptionResult {
+    const navigate = useNavigate();
+    const client = useRoomConnectionStore((s) => s.client);
+    const storeRoomId = useRoomConnectionStore((s) => s.roomId);
+    const clear = useRoomConnectionStore((s) => s.clear);
+
+    const [roomDetail, setRoomDetail] = useState<RoomDetailResponse | null>(null);
+    const [players, setPlayers] = useState<RoomMemberResponse[]>([]);
+    const [systemMessages, setSystemMessages] = useState<SystemMessage[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const handleEvent = useCallback((event: RoomEventMessage) => {
+        if (event.type === "JOINED") {
+            setPlayers((prev) => {
+                if (prev.some((p) => p.id === event.playerId)) return prev;
+                return [...prev, { id: event.playerId, nickname: event.nickname, isMaster: false }];
+            });
+            setSystemMessages((prev) => [
+                ...prev,
+                { type: "system", eventType: "join", targetNickname: event.nickname, timestamp: new Date().toISOString() },
+            ]);
+        } else if (event.type === "LEFT") {
+            setPlayers((prev) => prev.filter((p) => p.id !== event.playerId));
+            setSystemMessages((prev) => [
+                ...prev,
+                { type: "system", eventType: "leave", targetNickname: event.nickname, timestamp: new Date().toISOString() },
+            ]);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!client || storeRoomId !== roomId) {
+            navigate("/");
+            return;
+        }
+
+        const subscription = client.subscribe(`/topic/rooms/${roomId}`, (message) => {
+            const event: RoomEventMessage = JSON.parse(message.body);
+            handleEvent(event);
+        });
+
+        fetchRoomDetail(roomId)
+            .then((detail) => {
+                setRoomDetail(detail);
+                setPlayers(detail.players);
+            })
+            .finally(() => setIsLoading(false));
+
+        return () => {
+            subscription.unsubscribe();
+            client.deactivate();
+            clear();
+        };
+    }, [client, storeRoomId, roomId, navigate, handleEvent, clear]);
+
+    return { roomDetail, players, systemMessages, isLoading };
+}

--- a/front/app/routes/RoomView.tsx
+++ b/front/app/routes/RoomView.tsx
@@ -8,6 +8,7 @@ import ColumnsContainer from "~/components/layout/ColumnsContainer";
 import Column1 from "~/components/layout/Column1";
 import Column2 from "~/components/layout/Column2";
 import useBreakpoint from "~/hooks/useBreakpoint";
+import useRoomSubscription from "~/hooks/useRoomSubscription";
 import type RoomChatMessage from "~/utils/ChatMessage";
 
 const NEON_COLORS = [
@@ -26,64 +27,51 @@ function formatTime(timestamp: string): string {
     return d.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
 }
 
-interface MockPlayer {
-    id: number;
-    nickname: string;
-    isMaster: boolean;
-}
-
-const mockPlayers: MockPlayer[] = [
-    { id: 1, nickname: "ROOT#3465", isMaster: true },
-    { id: 2, nickname: "Hassium#0436", isMaster: false },
-    { id: 3, nickname: "MusicLover#1234", isMaster: false },
-];
-
-const mockMessages: RoomChatMessage[] = [
-    { type: "system", eventType: "join", targetNickname: "ROOT#3465", timestamp: "2026-03-23T14:00:00" },
-    { type: "message", senderId: 1, senderNickname: "ROOT#3465", content: "안녕하세요! 방장입니다.", timestamp: "2026-03-23T14:00:30" },
-    { type: "system", eventType: "join", targetNickname: "Hassium#0436", timestamp: "2026-03-23T14:01:00" },
-    { type: "message", senderId: 2, senderNickname: "Hassium#0436", content: "안녕하세요~", timestamp: "2026-03-23T14:01:15" },
-    { type: "message", senderId: 2, senderNickname: "Hassium#0436", content: "재밌어보이네요!", timestamp: "2026-03-23T14:01:20" },
-    { type: "message", senderId: 1, senderNickname: "ROOT#3465", content: "곧 시작할게요 잠시만 기다려주세요", timestamp: "2026-03-23T14:02:00" },
-    { type: "system", eventType: "join", targetNickname: "MusicLover#1234", timestamp: "2026-03-23T14:02:30" },
-    { type: "message", senderId: 3, senderNickname: "MusicLover#1234", content: "저도 참여합니다!", timestamp: "2026-03-23T14:02:45" },
-];
-
 export default function RoomView() {
     const { roomId } = useParams();
     const { isMobile } = useBreakpoint();
     const [showInfo, setShowInfo] = useState(false);
-    const title = "들어오셈";
-    const playlistTitle = "오늘의 TOP 100: 일본";
-    const playlistMaster = "ROOT#3465";
-    const playlistDescription = "오늘의 일본 인기곡 Top 100으로 구성된 맵입니다. 재미있게 즐겨 주세요!"
+
+    const { roomDetail, players, systemMessages, isLoading } = useRoomSubscription(Number(roomId));
+
+    if (isLoading || !roomDetail) {
+        return (
+            <AppShell variant="sub" title="로딩 중..." backTo="/">
+                <div className="flex items-center justify-center h-full">
+                    <div className="size-8 border-2 border-neon-cyan border-t-transparent rounded-full animate-spin" />
+                </div>
+            </AppShell>
+        );
+    }
+
+    const messages: RoomChatMessage[] = systemMessages;
 
     return (
         <AppShell
             variant="sub"
-            title={title}
+            title={roomDetail.title}
             backTo="/"
             actions={[{ icon: <PlayIcon />, label: "시작하기", onClick: () => {} }]}
         >
             <ColumnsContainer>
                 {(!isMobile || showInfo) && (
                     <Column1>
-                        <p className="text-4xl pt-4 font-bold hidden md:block">{title}</p>
+                        <p className="text-4xl pt-4 font-bold hidden md:block">{roomDetail.title}</p>
                         <div className="w-full p-3 md:p-4 flex flex-col gap-1 bg-zinc-800 rounded-2xl">
                             <div className="inline-flex items-end gap-1 text-lg md:text-2xl font-bold">
                                 <PlaylistIcon className="size-5 md:size-8" />
-                                <p>{playlistTitle}</p>
+                                <p>{roomDetail.playlist.title}</p>
                             </div>
-                            <p className="text-sm md:text-md text-zinc-400">by. {playlistMaster}</p>
-                            <p className="text-sm md:text-md mt-2 md:mt-4 text-zinc-200">{playlistDescription}</p>
+                            <p className="text-sm md:text-md text-zinc-400">by. {roomDetail.playlist.master}</p>
+                            <p className="text-sm md:text-md mt-2 md:mt-4 text-zinc-200">{roomDetail.playlist.description}</p>
                         </div>
                         <div className="w-full p-3 md:p-4 flex flex-col gap-1 md:gap-2 bg-zinc-800 rounded-2xl">
                             <div className="inline-flex items-end gap-1 text-lg md:text-2xl font-bold">
                                 <UsersIcon className="size-5 md:size-8" />
                                 <p>플레이어</p>
-                                <p className="text-sm md:text-lg">{mockPlayers.length}/16</p>
+                                <p className="text-sm md:text-lg">{players.length}</p>
                             </div>
-                            {mockPlayers.map((player) => (
+                            {players.map((player) => (
                                 <div key={player.id} className="flex items-center gap-2 md:gap-3 p-1.5 md:p-2 hover:bg-zinc-700/50 cursor-pointer rounded-lg transition-colors duration-200">
                                     <div className="relative">
                                         <UsersIcon className="size-7 md:size-10 rounded-full border border-zinc-600" />
@@ -119,7 +107,7 @@ export default function RoomView() {
                         </button>
                     )}
                     <div className="px-4 pt-4 w-full h-full shrink-1 flex flex-col gap-0.5 overflow-auto">
-                        {mockMessages.map((msg, index) => {
+                        {messages.map((msg, index) => {
                             if (msg.type === "system") {
                                 return (
                                     <div key={index} className="flex justify-center py-1.5">

--- a/front/app/utils/RoomDetailResponse.ts
+++ b/front/app/utils/RoomDetailResponse.ts
@@ -1,0 +1,20 @@
+export interface RoomMemberResponse {
+    id: number;
+    nickname: string;
+    isMaster: boolean;
+}
+
+export interface PlaylistDetailResponse {
+    id: number;
+    title: string;
+    count: number;
+    master: string;
+    description: string;
+}
+
+export default interface RoomDetailResponse {
+    id: number;
+    title: string;
+    playlist: PlaylistDetailResponse;
+    players: RoomMemberResponse[];
+}

--- a/front/app/utils/api.ts
+++ b/front/app/utils/api.ts
@@ -4,6 +4,7 @@ import type PlaylistResponse from "./PlaylistResponse";
 import type { PlaylistWithTracksResponse } from "./PlaylistResponse";
 import type PlaylistRequest from "./PlaylistRequest";
 import type PlaylistMetaDataResponse from "./PlaylistMetaDataResponse";
+import type RoomDetailResponse from "./RoomDetailResponse";
 
 // 즐겨찾기 요청용 내부 타입
 interface FavoritePlaylistRequest { playlistId: number }
@@ -86,4 +87,9 @@ export async function unfavoritePlaylist(playlistId: number): Promise<void> {
 
 export async function deletePlaylist(playlistId: number): Promise<void> {
     await client.delete(`/playlists/${playlistId}`);
+}
+
+export async function fetchRoomDetail(roomId: number): Promise<RoomDetailResponse> {
+    const response = await client.get<RoomDetailResponse>(`/rooms/${roomId}`);
+    return response.data;
 }


### PR DESCRIPTION
## Summary
- `RoomDetailResponse`, `RoomMemberResponse`, `PlaylistDetailResponse` 프론트엔드 타입 정의
- `fetchRoomDetail(roomId)` API 함수 추가
- `useRoomSubscription` 훅 — STOMP `/topic/rooms/{roomId}` 구독, JOINED/LEFT 이벤트 처리, 페이지 이탈 시 cleanup
- `RoomView` mock 데이터 제거, 서버 데이터로 교체 (플레이어 목록, 방 정보)
- URL 직접 접근 시 store에 Client 없으면 방 목록으로 리다이렉트

Depends on #192
Closes #190

## Test plan
- [ ] 방 입장 후 RoomView에서 실제 플레이어 목록 표시
- [ ] 다른 플레이어 입장 시 실시간 플레이어 목록 갱신 + 시스템 메시지 추가
- [ ] 다른 플레이어 퇴장 시 실시간 플레이어 목록 갱신 + 시스템 메시지 추가
- [ ] 뒤로가기 시 WebSocket 연결 해제 + store 초기화
- [ ] `/rooms/123` 직접 URL 접근 시 방 목록으로 리다이렉트

🤖 Generated with [Claude Code](https://claude.com/claude-code)