### PR TITLE
feat: 채팅 메시지 전송/수신 UI 구현

### DIFF
--- a/front/app/hooks/useRoomSubscription.ts
+++ b/front/app/hooks/useRoomSubscription.ts
@@ -1,25 +1,37 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import useRoomConnectionStore from "~/stores/RoomConnectionStore";
 import useMeStore from "~/stores/MeStore";
 import { fetchRoomDetail } from "~/utils/api";
 import type RoomDetailResponse from "~/utils/RoomDetailResponse";
 import type { RoomMemberResponse } from "~/utils/RoomDetailResponse";
-import type { SystemMessage } from "~/utils/ChatMessage";
+import type RoomChatMessage from "~/utils/ChatMessage";
 import type { StompSubscription } from "@stomp/stompjs";
 
-interface RoomEventMessage {
-    type: "JOINED" | "LEFT";
+interface RoomEventBase {
     roomId: number;
     playerId: number;
     nickname: string;
 }
 
+interface RoomJoinedLeftEvent extends RoomEventBase {
+    type: "JOINED" | "LEFT";
+}
+
+interface RoomChatEvent extends RoomEventBase {
+    type: "CHAT";
+    content: string;
+    timestamp: string;
+}
+
+type RoomEventMessage = RoomJoinedLeftEvent | RoomChatEvent;
+
 interface UseRoomSubscriptionResult {
     roomDetail: RoomDetailResponse | null;
     players: RoomMemberResponse[];
-    systemMessages: SystemMessage[];
+    messages: RoomChatMessage[];
     isLoading: boolean;
+    sendMessage: (content: string) => void;
     leaveRoom: () => void;
 }
 
@@ -32,7 +44,7 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
 
     const [roomDetail, setRoomDetail] = useState<RoomDetailResponse | null>(null);
     const [players, setPlayers] = useState<RoomMemberResponse[]>([]);
-    const [systemMessages, setSystemMessages] = useState<SystemMessage[]>([]);
+    const [messages, setMessages] = useState<RoomChatMessage[]>([]);
     const [isLoading, setIsLoading] = useState(true);
 
     const subscriptionRef = useRef<StompSubscription | null>(null);
@@ -59,7 +71,7 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
                 if (prev.some((p) => p.id === event.playerId)) return prev;
                 return [...prev, { id: event.playerId, nickname: event.nickname, isMaster: false }];
             });
-            setSystemMessages((prev) => [
+            setMessages((prev) => [
                 ...prev,
                 { type: "system", eventType: "join", targetNickname: event.nickname, timestamp: new Date().toISOString() },
             ]);
@@ -71,11 +83,22 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
                 return;
             }
             setPlayers((prev) => prev.filter((p) => p.id !== event.playerId));
-            setSystemMessages((prev) => [
+            setMessages((prev) => [
                 ...prev,
                 { type: "system", eventType: "leave", targetNickname: event.nickname, timestamp: new Date().toISOString() },
             ]);
+        } else if (event.type === "CHAT") {
+            setMessages((prev) => [
+                ...prev,
+                { type: "message", senderId: event.playerId, senderNickname: event.nickname, content: event.content, timestamp: event.timestamp },
+            ]);
         }
+    };
+
+    const sendMessageRef = useRef<(content: string) => void>(() => {});
+    sendMessageRef.current = (content: string) => {
+        if (!client?.connected) return;
+        client.publish({ destination: "/app/rooms/chat", body: JSON.stringify({ content }) });
     };
 
     const leaveRoomRef = useRef<() => void>(() => {});
@@ -126,11 +149,15 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
         };
     }, [client, storeRoomId, roomId, navigate, clear]);
 
+    const sendMessage = useCallback((content: string) => sendMessageRef.current(content), []);
+    const leaveRoom = useCallback(() => leaveRoomRef.current(), []);
+
     return {
         roomDetail,
         players,
-        systemMessages,
+        messages,
         isLoading,
-        leaveRoom: () => leaveRoomRef.current(),
+        sendMessage,
+        leaveRoom,
     };
 }

--- a/front/app/routes/RoomView.tsx
+++ b/front/app/routes/RoomView.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import AppShell from "~/components/layout/AppShell";
 import PlayIcon from "~/assets/play.svg?react";
 import PlaylistIcon from "~/assets/playlist.svg?react";
@@ -9,7 +9,6 @@ import Column1 from "~/components/layout/Column1";
 import Column2 from "~/components/layout/Column2";
 import useBreakpoint from "~/hooks/useBreakpoint";
 import useRoomSubscription from "~/hooks/useRoomSubscription";
-import type RoomChatMessage from "~/utils/ChatMessage";
 
 const NEON_COLORS = [
     "text-neon-cyan",
@@ -32,7 +31,25 @@ export default function RoomView() {
     const { isMobile } = useBreakpoint();
     const [showInfo, setShowInfo] = useState(false);
 
-    const { roomDetail, players, systemMessages, isLoading, leaveRoom } = useRoomSubscription(Number(roomId));
+    const [input, setInput] = useState("");
+    const messagesContainerRef = useRef<HTMLDivElement>(null);
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+    const isNearBottomRef = useRef(true);
+
+    const { roomDetail, players, messages, isLoading, sendMessage, leaveRoom } = useRoomSubscription(Number(roomId));
+
+    useEffect(() => {
+        if (isNearBottomRef.current) {
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        }
+    }, [messages]);
+
+    function handleSend() {
+        const trimmed = input.trim();
+        if (!trimmed) return;
+        sendMessage(trimmed);
+        setInput("");
+    }
 
     if (isLoading || !roomDetail) {
         return (
@@ -43,8 +60,6 @@ export default function RoomView() {
             </AppShell>
         );
     }
-
-    const messages: RoomChatMessage[] = systemMessages;
 
     return (
         <AppShell
@@ -106,7 +121,15 @@ export default function RoomView() {
                             </svg>
                         </button>
                     )}
-                    <div className="px-4 pt-4 w-full h-full shrink-1 flex flex-col gap-0.5 overflow-auto">
+                    <div
+                        ref={messagesContainerRef}
+                        className="px-4 pt-4 w-full h-full shrink-1 flex flex-col gap-0.5 overflow-auto"
+                        onScroll={() => {
+                            const el = messagesContainerRef.current;
+                            if (!el) return;
+                            isNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+                        }}
+                    >
                         {messages.map((msg, index) => {
                             if (msg.type === "system") {
                                 return (
@@ -132,13 +155,33 @@ export default function RoomView() {
                                 </div>
                             );
                         })}
+                        <div ref={messagesEndRef} />
                     </div>
-                    <div className="p-2 m-2 rounded-full bg-surface border border-border focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
+                    <div className="p-2 m-2 flex items-center gap-2 rounded-full bg-surface border border-border focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
                         <input
                             type="text"
                             placeholder="보낼 메시지 입력"
-                            className="w-full p-[2px] pl-[8px] placeholder-zinc-500 focus:outline-none"
+                            className="flex-1 p-[2px] pl-[8px] placeholder-zinc-500 focus:outline-none"
+                            value={input}
+                            onChange={(e) => setInput(e.target.value)}
+                            maxLength={200}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                                    e.preventDefault();
+                                    handleSend();
+                                }
+                            }}
                         />
+                        <button
+                            type="button"
+                            className="size-7 flex items-center justify-center rounded-full bg-neon-cyan/20 text-neon-cyan hover:bg-neon-cyan/30 disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer shrink-0"
+                            disabled={!input.trim()}
+                            onClick={handleSend}
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="size-4">
+                                <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.926A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.086l-1.414 4.926a.75.75 0 0 0 .826.95l14.095-5.637a.75.75 0 0 0 0-1.394L3.105 2.289Z" />
+                            </svg>
+                        </button>
                     </div>
                 </Column2>
             </ColumnsContainer>

--- a/front/app/routes/RoomView.tsx
+++ b/front/app/routes/RoomView.tsx
@@ -32,6 +32,7 @@ export default function RoomView() {
     const [showInfo, setShowInfo] = useState(false);
 
     const [input, setInput] = useState("");
+    const inputRef = useRef<HTMLInputElement>(null);
     const messagesContainerRef = useRef<HTMLDivElement>(null);
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const isNearBottomRef = useRef(true);
@@ -43,6 +44,17 @@ export default function RoomView() {
             messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
         }
     }, [messages]);
+
+    useEffect(() => {
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === "Enter" && document.activeElement !== inputRef.current) {
+                e.preventDefault();
+                inputRef.current?.focus();
+            }
+        }
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, []);
 
     function handleSend() {
         const trimmed = input.trim();
@@ -159,6 +171,7 @@ export default function RoomView() {
                     </div>
                     <div className="p-2 m-2 flex items-center gap-2 rounded-full bg-surface border border-border focus-within:border-neon-cyan focus-within:shadow-glow-cyan transition-all duration-200">
                         <input
+                            ref={inputRef}
                             type="text"
                             placeholder="보낼 메시지 입력"
                             className="flex-1 p-[2px] pl-[8px] placeholder-zinc-500 focus:outline-none"


### PR DESCRIPTION
## Summary
- `useRoomSubscription` 훅에 CHAT 이벤트 처리 및 `sendMessage` 함수 추가
- `RoomView`에 입력 상태 관리, Enter 키/전송 버튼 전송, 200자 제한, 자동 스크롤 구현
- 시스템 메시지(입퇴장)와 채팅 메시지를 통합 `messages` 배열로 관리

Closes #201

## Test plan
- [ ] 입력 필드에 메시지를 입력하고 Enter를 누르면 같은 방의 모든 사용자에게 메시지가 표시된다
- [x] 전송 버튼 클릭으로도 메시지가 전송된다
- [x] 빈 메시지는 전송되지 않는다 (Enter, 버튼 모두)
- [x] 200자를 초과하는 입력이 제한된다 (maxLength)
- [x] 메시지에 발신자 닉네임과 시간이 함께 표시된다
- [x] 시스템 메시지(입퇴장)와 채팅 메시지가 시간순으로 함께 표시된다
- [x] 새 메시지 도착 시 하단 근처에 있으면 자동 스크롤된다
- [x] 사용자가 위로 스크롤한 상태에서는 자동 스크롤되지 않는다
- [x] 한국어 입력 시 IME 조합 중 Enter가 메시지를 전송하지 않는다

🤖 Generated with [Claude Code](https://claude.com/claude-code)