### PR TITLE
feat: Redis 기반 활성 세션 매니저 및 세션 교체 이벤트 DTO 구현

### DIFF
--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/redis/ActiveSessionManager.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/redis/ActiveSessionManager.kt
@@ -1,0 +1,65 @@
+package ilpak.nomat.infrastructure.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+@Service
+class ActiveSessionManager(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+) {
+
+    fun getSession(playerId: Long): SessionInfo? {
+        val value = redisTemplate.opsForValue().get(keyFor(playerId)) ?: return null
+        return objectMapper.readValue(value, SessionInfo::class.java)
+    }
+
+    fun setSession(playerId: Long, sessionId: String, roomId: Long) {
+        val value = objectMapper.writeValueAsString(SessionInfo(sessionId, roomId))
+        redisTemplate.opsForValue().set(keyFor(playerId), value, SESSION_TTL)
+    }
+
+    fun isActiveSession(playerId: Long, sessionId: String): Boolean {
+        val session = getSession(playerId) ?: return false
+        return session.sessionId == sessionId
+    }
+
+    fun removeSession(playerId: Long, sessionId: String): Boolean {
+        val result = redisTemplate.execute(
+            REMOVE_SESSION_SCRIPT,
+            listOf(keyFor(playerId)),
+            sessionId,
+        )
+        return result == 1L
+    }
+
+    private fun keyFor(playerId: Long): String = "$KEY_PREFIX$playerId"
+
+    companion object {
+        private const val KEY_PREFIX = "player:session:"
+        private val SESSION_TTL = Duration.ofHours(24)
+
+        private val REMOVE_SESSION_SCRIPT = DefaultRedisScript<Long>(
+            """
+            local value = redis.call('GET', KEYS[1])
+            if value then
+                local session = cjson.decode(value)
+                if session['sessionId'] == ARGV[1] then
+                    redis.call('DEL', KEYS[1])
+                    return 1
+                end
+            end
+            return 0
+            """.trimIndent(),
+            Long::class.javaObjectType,
+        )
+    }
+}
+
+data class SessionInfo(
+    val sessionId: String,
+    val roomId: Long,
+)

--- a/back/src/main/kotlin/ilpak/nomat/room/application/dto/RoomEventMessage.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/dto/RoomEventMessage.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
     JsonSubTypes.Type(value = RoomJoinedEventMessage::class, name = "JOINED"),
     JsonSubTypes.Type(value = RoomLeftEventMessage::class, name = "LEFT"),
     JsonSubTypes.Type(value = RoomChatEventMessage::class, name = "CHAT"),
+    JsonSubTypes.Type(value = SessionReplacedEventMessage::class, name = "SESSION_REPLACED"),
 )
 interface RoomEventMessage {
     val roomId: Long

--- a/back/src/main/kotlin/ilpak/nomat/room/application/dto/SessionReplacedEventMessage.kt
+++ b/back/src/main/kotlin/ilpak/nomat/room/application/dto/SessionReplacedEventMessage.kt
@@ -1,0 +1,7 @@
+package ilpak.nomat.room.application.dto
+
+data class SessionReplacedEventMessage(
+    override val roomId: Long,
+    override val playerId: Long,
+    override val nickname: String,
+) : RoomEventMessage

--- a/back/src/test/kotlin/ilpak/nomat/infrastructure/redis/ActiveSessionManagerTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/infrastructure/redis/ActiveSessionManagerTest.kt
@@ -1,0 +1,88 @@
+package ilpak.nomat.infrastructure.redis
+
+import ilpak.nomat.infrastructure.integration.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+@IntegrationTest
+class ActiveSessionManagerTest(
+    @Autowired private val activeSessionManager: ActiveSessionManager,
+) {
+
+    @Test
+    fun `setSession_세션을 등록하고 조회한다`() {
+        activeSessionManager.setSession(1L, "session-1", 100L)
+
+        val session = activeSessionManager.getSession(1L)
+
+        assertThat(session).isNotNull
+        assertThat(session!!.sessionId).isEqualTo("session-1")
+        assertThat(session.roomId).isEqualTo(100L)
+    }
+
+    @Test
+    fun `getSession_등록되지 않은 플레이어는 null을 반환한다`() {
+        val session = activeSessionManager.getSession(999L)
+
+        assertThat(session).isNull()
+    }
+
+    @Test
+    fun `setSession_기존 세션을 새 세션으로 갱신한다`() {
+        activeSessionManager.setSession(1L, "session-old", 100L)
+        activeSessionManager.setSession(1L, "session-new", 200L)
+
+        val session = activeSessionManager.getSession(1L)
+
+        assertThat(session).isNotNull
+        assertThat(session!!.sessionId).isEqualTo("session-new")
+        assertThat(session.roomId).isEqualTo(200L)
+    }
+
+    @Test
+    fun `isActiveSession_현재 활성 세션이면 true를 반환한다`() {
+        activeSessionManager.setSession(1L, "session-1", 100L)
+
+        assertThat(activeSessionManager.isActiveSession(1L, "session-1")).isTrue()
+    }
+
+    @Test
+    fun `isActiveSession_다른 세션이면 false를 반환한다`() {
+        activeSessionManager.setSession(1L, "session-1", 100L)
+
+        assertThat(activeSessionManager.isActiveSession(1L, "session-other")).isFalse()
+    }
+
+    @Test
+    fun `isActiveSession_세션이 없으면 false를 반환한다`() {
+        assertThat(activeSessionManager.isActiveSession(999L, "session-1")).isFalse()
+    }
+
+    @Test
+    fun `removeSession_세션 ID가 일치하면 삭제하고 true를 반환한다`() {
+        activeSessionManager.setSession(1L, "session-1", 100L)
+
+        val result = activeSessionManager.removeSession(1L, "session-1")
+
+        assertThat(result).isTrue()
+        assertThat(activeSessionManager.getSession(1L)).isNull()
+    }
+
+    @Test
+    fun `removeSession_세션 ID가 불일치하면 삭제하지 않고 false를 반환한다`() {
+        activeSessionManager.setSession(1L, "session-1", 100L)
+
+        val result = activeSessionManager.removeSession(1L, "session-other")
+
+        assertThat(result).isFalse()
+        assertThat(activeSessionManager.getSession(1L)).isNotNull()
+    }
+
+    @Test
+    fun `removeSession_세션이 없으면 false를 반환한다`() {
+        val result = activeSessionManager.removeSession(999L, "session-1")
+
+        assertThat(result).isFalse()
+    }
+}

--- a/back/src/test/kotlin/ilpak/nomat/room/application/dto/SessionReplacedEventMessageTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/room/application/dto/SessionReplacedEventMessageTest.kt
@@ -1,0 +1,40 @@
+package ilpak.nomat.room.application.dto
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SessionReplacedEventMessageTest {
+
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    @Test
+    fun `직렬화 시 type 필드가 SESSION_REPLACED로 포함된다`() {
+        val message: RoomEventMessage = SessionReplacedEventMessage(
+            roomId = 1L,
+            playerId = 2L,
+            nickname = "testUser",
+        )
+
+        val json = objectMapper.writeValueAsString(message)
+
+        assertThat(json).contains("\"type\":\"SESSION_REPLACED\"")
+        assertThat(json).contains("\"roomId\":1")
+        assertThat(json).contains("\"playerId\":2")
+        assertThat(json).contains("\"nickname\":\"testUser\"")
+    }
+
+    @Test
+    fun `역직렬화 시 SessionReplacedEventMessage로 복원된다`() {
+        val json = """{"type":"SESSION_REPLACED","roomId":1,"playerId":2,"nickname":"testUser"}"""
+
+        val message = objectMapper.readValue(json, RoomEventMessage::class.java)
+
+        assertThat(message).isInstanceOf(SessionReplacedEventMessage::class.java)
+        val sessionReplaced = message as SessionReplacedEventMessage
+        assertThat(sessionReplaced.roomId).isEqualTo(1L)
+        assertThat(sessionReplaced.playerId).isEqualTo(2L)
+        assertThat(sessionReplaced.nickname).isEqualTo("testUser")
+    }
+}


### PR DESCRIPTION
## Summary
- `ActiveSessionManager` 신규 생성: Redis GET/SET/DEL 기반 활성 세션 CRUD (TTL 24시간, Lua 스크립트 원자적 삭제)
- `SessionReplacedEventMessage` 신규 생성: `RoomEventMessage` 다형성 직렬화 지원 (`SESSION_REPLACED` 타입)
- `RoomEventMessage`의 `@JsonSubTypes`에 `SESSION_REPLACED` 항목 추가

Closes #205

## Test plan
- [x] `ActiveSessionManagerTest` — 세션 등록/조회/갱신/삭제 통합 테스트 (9개 케이스, Testcontainers Redis)
- [x] `SessionReplacedEventMessageTest` — JSON 직렬화/역직렬화 단위 테스트 (2개 케이스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)