### PR TITLE
feat: 세션 교체 이벤트 핸들링 및 비활성화 오버레이 UI 구현

### DIFF
--- a/front/app/hooks/useRoomSubscription.ts
+++ b/front/app/hooks/useRoomSubscription.ts
@@ -18,19 +18,24 @@ interface RoomJoinedLeftEvent extends RoomEventBase {
     type: "JOINED" | "LEFT";
 }
 
+interface RoomSessionReplacedEvent extends RoomEventBase {
+    type: "SESSION_REPLACED";
+}
+
 interface RoomChatEvent extends RoomEventBase {
     type: "CHAT";
     content: string;
     timestamp: string;
 }
 
-type RoomEventMessage = RoomJoinedLeftEvent | RoomChatEvent;
+type RoomEventMessage = RoomJoinedLeftEvent | RoomSessionReplacedEvent | RoomChatEvent;
 
 interface UseRoomSubscriptionResult {
     roomDetail: RoomDetailResponse | null;
     players: RoomMemberResponse[];
     messages: RoomChatMessage[];
     isLoading: boolean;
+    isDeactivated: boolean;
     sendMessage: (content: string) => void;
     leaveRoom: () => void;
 }
@@ -46,9 +51,12 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
     const [players, setPlayers] = useState<RoomMemberResponse[]>([]);
     const [messages, setMessages] = useState<RoomChatMessage[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [isDeactivated, setIsDeactivated] = useState(false);
 
     const subscriptionRef = useRef<StompSubscription | null>(null);
     const disconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isLeavingVoluntarilyRef = useRef(false);
+    const isDeactivatedRef = useRef(false);
 
     function clearPendingTimeout() {
         if (disconnectTimeoutRef.current) {
@@ -64,6 +72,12 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
         clear();
     }
 
+    function deactivate() {
+        isDeactivatedRef.current = true;
+        setIsDeactivated(true);
+        disconnectAndCleanup();
+    }
+
     const handleEventRef = useRef<(event: RoomEventMessage) => void>(() => {});
     handleEventRef.current = (event: RoomEventMessage) => {
         if (event.type === "JOINED") {
@@ -75,11 +89,20 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
                 ...prev,
                 { type: "system", eventType: "join", targetNickname: event.nickname, timestamp: new Date().toISOString() },
             ]);
+        } else if (event.type === "SESSION_REPLACED") {
+            if (event.playerId === meId) {
+                deactivate();
+                return;
+            }
         } else if (event.type === "LEFT") {
             if (event.playerId === meId) {
                 clearPendingTimeout();
-                disconnectAndCleanup();
-                navigate("/");
+                if (isLeavingVoluntarilyRef.current) {
+                    disconnectAndCleanup();
+                    navigate("/");
+                } else {
+                    deactivate();
+                }
                 return;
             }
             setPlayers((prev) => prev.filter((p) => p.id !== event.playerId));
@@ -104,6 +127,7 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
     const leaveRoomRef = useRef<() => void>(() => {});
     leaveRoomRef.current = () => {
         clearPendingTimeout();
+        isLeavingVoluntarilyRef.current = true;
         if (client?.connected) {
             client.publish({ destination: "/app/rooms/leave" });
         }
@@ -116,6 +140,8 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
 
     useEffect(() => {
         clearPendingTimeout();
+
+        if (isDeactivatedRef.current) return;
 
         if (!client || storeRoomId !== roomId) {
             navigate("/");
@@ -137,6 +163,8 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
         }
 
         return () => {
+            if (isDeactivatedRef.current) return;
+
             // StrictMode 재마운트 시 취소되도록 지연 정리
             disconnectTimeoutRef.current = setTimeout(() => {
                 if (!subscriptionRef.current) return;
@@ -157,6 +185,7 @@ export default function useRoomSubscription(roomId: number): UseRoomSubscription
         players,
         messages,
         isLoading,
+        isDeactivated,
         sendMessage,
         leaveRoom,
     };

--- a/front/app/routes/RoomView.tsx
+++ b/front/app/routes/RoomView.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import { useEffect, useRef, useState } from "react";
 import AppShell from "~/components/layout/AppShell";
 import PlayIcon from "~/assets/play.svg?react";
@@ -28,6 +28,7 @@ function formatTime(timestamp: string): string {
 
 export default function RoomView() {
     const { roomId } = useParams();
+    const navigate = useNavigate();
     const { isMobile } = useBreakpoint();
     const [showInfo, setShowInfo] = useState(false);
 
@@ -37,7 +38,7 @@ export default function RoomView() {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const isNearBottomRef = useRef(true);
 
-    const { roomDetail, players, messages, isLoading, sendMessage, leaveRoom } = useRoomSubscription(Number(roomId));
+    const { roomDetail, players, messages, isLoading, isDeactivated, sendMessage, leaveRoom } = useRoomSubscription(Number(roomId));
 
     useEffect(() => {
         if (isNearBottomRef.current) {
@@ -198,6 +199,18 @@ export default function RoomView() {
                     </div>
                 </Column2>
             </ColumnsContainer>
+            {isDeactivated && (
+                <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 bg-zinc-950/80 backdrop-blur-sm">
+                    <p className="text-xl font-bold text-zinc-200">다른 탭에서 사용 중입니다</p>
+                    <button
+                        type="button"
+                        className="px-6 py-2.5 rounded-xl bg-neon-cyan/20 text-neon-cyan font-semibold hover:bg-neon-cyan/30 transition-colors cursor-pointer"
+                        onClick={() => navigate("/")}
+                    >
+                        방 목록으로 이동
+                    </button>
+                </div>
+            )}
         </AppShell>
     );
 }


### PR DESCRIPTION
## Summary
- `useRoomSubscription` 훅에 `SESSION_REPLACED` 이벤트 핸들링 추가
- `isLeavingVoluntarily` ref로 자발적 퇴장과 세션 교체로 인한 강제 퇴장 구분
- `isDeactivated` 상태 반환 및 `isDeactivatedRef`로 cleanup/effect 가드 처리
- `RoomView`에 비활성화 시 전체 화면 오버레이 ("다른 탭에서 사용 중입니다") 표시

Closes #207

## Test plan
- [ ] 같은 방에서 새 탭으로 접속 시 기존 탭에 "다른 탭에서 사용 중입니다" 오버레이 표시 확인
- [ ] 다른 방에서 새 탭으로 접속 시 기존 탭에 오버레이 표시 확인
- [x] 비활성화된 탭에서 채팅 전송 불가 확인
- [x] 비활성화된 탭의 "방 목록으로 이동" 버튼 동작 확인
- [ ] 사용자가 직접 퇴장 버튼 클릭 시 기존대로 방 목록 이동 확인
- [x] 비활성화된 탭 언마운트 시 leave 메시지 재전송되지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)