### PR TITLE
fix: logstash-logback-encoder 7.4→8.1 상향으로 access 로그 NoClassDefFoundError 해결

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
 	implementation("org.springframework.data:spring-data-elasticsearch")
 	implementation("org.springframework.retry:spring-retry")
 	implementation("io.jsonwebtoken:jjwt-api:0.12.6")
-	implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+	implementation("net.logstash.logback:logstash-logback-encoder:8.1")
 	implementation("ch.qos.logback.access:logback-access-common:2.0.6")
 	implementation("ch.qos.logback.access:logback-access-tomcat:2.0.6")
 	implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")


### PR DESCRIPTION
## 요약
`net.logstash.logback:logstash-logback-encoder` 의존성을 `7.4`에서 `8.1`로 올린다. 기존 7.4는 `logback-access` 1.x 기준이라 현재 프로젝트의 `logback-access 2.0.6`(Jakarta)과 비호환이며, access 로그 인코딩 시 `NoClassDefFoundError: ch/qos/logback/access/spi/IAccessEvent`가 발생한다. 8.x는 logback 1.5 + logback-access 2.0을 대상으로 하여 호환 문제가 해소된다.

## 배경
`back/build.gradle.kts`에는 `logback-access-common:2.0.6` / `logback-access-tomcat:2.0.6`(Spring Boot 3.4 / Tomcat 10 / Jakarta)이 들어 있다. logback-access 2.0부터 `IAccessEvent`가 `ch.qos.logback.access.spi` → `ch.qos.logback.access.**common**.spi`로 이동했는데, encoder 7.4의 `AccessEventFormattedTimestampJsonProvider`는 구 경로를 참조한다. 그 결과 `LogstashAccessEncoder`가 access 이벤트를 직렬화할 때 런타임에 클래스를 찾지 못해 `NoClassDefFoundError`로 실패한다.

기존 access appender가 비동기 TCP(`LogstashAccessTcpSocketAppender`)였을 때는 인코딩이 백그라운드 writer 스레드에서 일어나 예외가 logback 내부에서 삼켜져 잠복했으나, access 로그를 동기(`ConsoleAppender`)로 출력하도록 바꾸면 예외가 요청 스레드(`LogbackValve`)로 전파되어 `/health` 등 요청 처리까지 깨뜨린다. 이 PR은 그 근본 원인인 **버전 비호환** 자체를 먼저 제거한다.

## 주요 변경
- `back/build.gradle.kts`: `net.logstash.logback:logstash-logback-encoder` `7.4` → `8.1`. (`logback-classic 1.5.18`, `logback-access-common/tomcat 2.0.6`과 정합)

## 테스트
- [x] `javap`로 `logstash-logback-encoder:8.1`의 `AccessEventFormattedTimestampJsonProvider`가 `ch.qos.logback.access.common.spi.IAccessEvent`를 참조함을 확인 (2.0.6 jar가 해당 클래스를 제공함도 확인)
- [x] `./gradlew build` 통과 (compile + 전체 Testcontainers 테스트)
- [ ] dev 배포 후 access 로그 정상 인코딩 및 `/health` 200 응답 확인 (test 프로파일은 plain pattern이라 access 인코더를 런타임에 태우지 않음 → 배포 검증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)