### PR TITLE
ci: docker stack deploy 안정화 — --prune + 배포 수렴(롤백) 검증

### DIFF
--- a/.github/workflows/back-push-develop.yml
+++ b/.github/workflows/back-push-develop.yml
@@ -57,4 +57,31 @@ jobs:
           
           export $(xargs < .env)
           NOMAT_TAG=${{ github.sha }} docker stack config -c compose.yml | sudo docker stack deploy --prune -c - nomat-back
+
+          echo "Waiting for spring-app deployment to converge..."
+          sleep 10
+          CONVERGED=0
+          for i in $(seq 1 60); do
+          STATE=$(sudo docker service inspect nomat-back_spring-app --format "{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}")
+          REPLICAS=$(sudo docker service ls --filter name=nomat-back_spring-app --format "{{.Replicas}}")
+          echo "attempt $i: UpdateStatus=[$STATE] replicas=[$REPLICAS]"
+          case "$STATE" in
+          paused|rollback_started|rollback_paused|rollback_completed)
+          echo "Deployment FAILED (state: $STATE) - spring-app rolled back or paused."
+          exit 1
+          ;;
+          esac
+          RUNNING=${REPLICAS%%/*}
+          DESIRED=${REPLICAS##*/}
+          if { [ "$STATE" = completed ] || [ -z "$STATE" ]; } && [ -n "$RUNNING" ] && [ "$RUNNING" = "$DESIRED" ]; then
+          echo "Deployment converged ($REPLICAS)."
+          CONVERGED=1
+          break
+          fi
+          sleep 5
+          done
+          if [ "$CONVERGED" -ne 1 ]; then
+          echo "Timed out waiting for spring-app to converge."
+          exit 1
+          fi
           '

--- a/.github/workflows/back-push-develop.yml
+++ b/.github/workflows/back-push-develop.yml
@@ -56,5 +56,5 @@ jobs:
           cd infra
           
           export $(xargs < .env)
-          NOMAT_TAG=${{ github.sha }} docker stack config -c compose.yml | sudo docker stack deploy -c - nomat-back
+          NOMAT_TAG=${{ github.sha }} docker stack config -c compose.yml | sudo docker stack deploy --prune -c - nomat-back
           '

--- a/.github/workflows/infra-push-develop.yml
+++ b/.github/workflows/infra-push-develop.yml
@@ -42,4 +42,31 @@ jobs:
 
           export $(xargs < .env)
           docker stack config -c compose.yml | sudo docker stack deploy --prune -c - nomat-back
+
+          echo "Waiting for spring-app deployment to converge..."
+          sleep 10
+          CONVERGED=0
+          for i in $(seq 1 60); do
+          STATE=$(sudo docker service inspect nomat-back_spring-app --format "{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}")
+          REPLICAS=$(sudo docker service ls --filter name=nomat-back_spring-app --format "{{.Replicas}}")
+          echo "attempt $i: UpdateStatus=[$STATE] replicas=[$REPLICAS]"
+          case "$STATE" in
+          paused|rollback_started|rollback_paused|rollback_completed)
+          echo "Deployment FAILED (state: $STATE) - spring-app rolled back or paused."
+          exit 1
+          ;;
+          esac
+          RUNNING=${REPLICAS%%/*}
+          DESIRED=${REPLICAS##*/}
+          if { [ "$STATE" = completed ] || [ -z "$STATE" ]; } && [ -n "$RUNNING" ] && [ "$RUNNING" = "$DESIRED" ]; then
+          echo "Deployment converged ($REPLICAS)."
+          CONVERGED=1
+          break
+          fi
+          sleep 5
+          done
+          if [ "$CONVERGED" -ne 1 ]; then
+          echo "Timed out waiting for spring-app to converge."
+          exit 1
+          fi
           '

--- a/.github/workflows/infra-push-develop.yml
+++ b/.github/workflows/infra-push-develop.yml
@@ -41,5 +41,5 @@ jobs:
           cd infra
 
           export $(xargs < .env)
-          docker stack config -c compose.yml | sudo docker stack deploy -c - nomat-back
+          docker stack config -c compose.yml | sudo docker stack deploy --prune -c - nomat-back
           '


### PR DESCRIPTION
## 요약
CI 배포 단계의 `docker stack deploy`를 두 가지로 안정화한다. (1) `--prune`을 추가해 compose에서 삭제된 서비스가 자동 제거되도록 하고, (2) 배포 직후 spring-app의 수렴 상태를 폴링해 **롤백/실패 시 워크플로우가 명시적으로 실패(exit 1)** 하도록 한다.

## 배경
- **prune**: `docker stack deploy`는 기본적으로 compose에 있는 서비스만 생성/업데이트하고 빠진 서비스는 두므로(제거하려면 `--prune` 필요), observability 교체로 compose에서 뺀 `kibana`/`grafana`/`prometheus`가 배포 후에도 `docker service ls`에 계속 떠 있었다.
- **수렴 검증**: `docker stack deploy`는 비동기라 서비스 스펙 제출 직후 종료코드 0을 반환한다. 따라서 새 태스크가 `/health` 헬스체크를 통과하지 못해 `failure_action: rollback`으로 롤백되어도 CI는 이를 감지하지 못하고 **실패한 배포를 green으로 통과**시킨다(docker/cli #6752). 배포 성공/실패가 CI에 정확히 반영되도록 수렴 폴링을 추가한다.

## 주요 변경
- `.github/workflows/infra-push-develop.yml`, `.github/workflows/back-push-develop.yml`:
  - `docker stack deploy` → `docker stack deploy --prune`
  - 배포 후 `nomat-back_spring-app`의 `UpdateStatus.State`를 5초 간격으로 최대 ~5분 폴링:
    - `rollback_started`/`rollback_paused`/`rollback_completed`/`paused` → `exit 1` (배포 실패로 처리)
    - `completed`(또는 최초 배포라 빈 값)이면서 running replica == desired replica → 성공
    - 시간 내 미수렴 → `exit 1`

## 테스트
- [x] 두 워크플로우 YAML 파싱 정상(ruby YAML), 추가한 폴링 bash 블록 `bash -n` 문법 통과
- [ ] develop 머지 후 정상 배포 시 워크플로우 green + compose에서 뺀 서비스 자동 제거 확인
- [ ] 의도적으로 헬스체크 실패하는 이미지 배포 시 롤백 발생 + 워크플로우 red 확인

## 참고 (`--prune`이 정리하지 않는 것 — 수동)
- `local-prometheus` 오버레이 네트워크 → `docker network rm`
- `prometheus-data`/`grafana-data` 볼륨 → 자동 삭제 안 됨(안정 운영 후 `docker volume rm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
