### PR TITLE
feat: JVM·Spring Boot 앱 메트릭 prometheus endpoint 노출 + Alloy replica별 scrape

### DIFF
--- a/back/CLAUDE.md
+++ b/back/CLAUDE.md
@@ -200,12 +200,23 @@ await()
 
 ## 운영 엔드포인트
 
-- `/info` — Spring Boot Actuator. 빌드 시점에 박힌 git 메타(`build.commit`, `build.branch`)와 artifact 정보(`build.artifact`, `build.name`, `build.version`, `build.time`)를 반환. **인증 없음(permitAll)**. 값은 빌드 시 `back/Dockerfile`의 `ARG GIT_COMMIT`/`ARG GIT_BRANCH` → Gradle property → `springBoot.buildInfo.additional`로 jar 안 `META-INF/build-info.properties`에 박히며, 런타임 ENV로 변조 불가. CI(`back-push-develop.yml`)에서 `${{ github.sha }}`/`${{ github.ref_name }}`로 주입. 로컬 빌드는 `unknown` fallback.
-- `/health` — Liveness. components 표시는 익명, 상세는 인증 필요. Redis pub/sub 헬스 컴포넌트 포함.
+### 관리 포트 분리 (dev 프로파일)
+
+dev 프로파일에서 actuator 전체는 `management.server.port: 8081` 전용 관리 포트로 분리된다(`local`/`test`는 메인 8080 포트 유지 — 기존 테스트·로컬 동작 보존). 관리 포트는 **내부 전용**이며 인증을 요구하지 않는다 — 메인 보안 체인(OAuth2/STATELESS/`Http403ForbiddenEntryPoint`)이 적용되면 Alloy가 403을 맞으므로, `EndpointRequest.toAnyEndpoint()`를 매칭하는 별도 `permitAll` 체인(`ManagementSecurityConfiguration`, `@Order(1)`, `@Profile("!test")`)을 둔다. 메인 `SecurityConfiguration.permittedUrls`에서는 actuator가 더 이상 메인 포트에 없으므로 `/health/**`·`/info/**`를 제거했다.
+
+공개 노출은 nginx가 `/info` 하나만 관리 포트로 reverse proxy한다(allow-list, default-closed). `/health`는 컨테이너 내부 healthcheck(`localhost:8081/health`) 전용, `/prometheus`는 내부 Alloy scrape 전용 — 둘 다 공개 ingress로 도달 불가.
+
+### 엔드포인트
+
+- `/info` — Spring Boot Actuator. 빌드 시점에 박힌 git 메타(`build.commit`, `build.branch`)와 artifact 정보(`build.artifact`, `build.name`, `build.version`, `build.time`)를 반환. **인증 없음(관리 체인 permitAll)**. 값은 빌드 시 `back/Dockerfile`의 `ARG GIT_COMMIT`/`ARG GIT_BRANCH` → Gradle property → `springBoot.buildInfo.additional`로 jar 안 `META-INF/build-info.properties`에 박히며, 런타임 ENV로 변조 불가. CI(`back-push-develop.yml`)에서 `${{ github.sha }}`/`${{ github.ref_name }}`로 주입. 로컬 빌드는 `unknown` fallback. dev에서는 관리 포트(8081)·공개는 nginx 경유.
+- `/health` — Liveness. components 표시는 익명, 상세는 인증 필요. Redis pub/sub 헬스 컴포넌트 포함. dev에서는 관리 포트(8081)에서 제공, 공개 미노출.
+- `/prometheus` — Micrometer/Actuator Prometheus exposition. `io.micrometer:micrometer-registry-prometheus`(runtimeOnly)로 활성화하고 `management.endpoints.web.exposure.include`에 `prometheus` 포함. JVM(heap/GC/스레드)·HTTP 요청·HikariCP·logback·tomcat 등 기본 Micrometer 메트릭을 노출하며, 내부 네트워크의 Alloy만 scrape한다(공개 미노출). 카디널리티 가드로 `management.metrics.distribution.percentiles-histogram.http.server.requests: false`를 명시(히스토그램 `_bucket` 미생성). **신규 엔드포인트의 URI는 반드시 템플릿화**(`@PathVariable`)하고 path에 UUID/이메일 등 unbounded 값을 직접 박지 않는다 — `http_server_requests`의 `uri` 라벨 카디널리티 무한 증식 방지.
+
+> 테스트에서 prometheus endpoint를 검증할 때는 `@AutoConfigureObservability`를 붙여야 한다 — `@SpringBootTest`는 기본적으로 metrics export를 끈다(`management.defaults.metrics.export.enabled=false`).
 
 ## Observability (로그·메트릭)
 
-dev 프로파일의 로그는 더 이상 Logstash로 직접 TCP 송신하지 않는다. logback은 **stdout에 JSON 라인**으로 출력하며(`logback-spring.xml`의 `ConsoleAppender` + `LogstashEncoder`, access 로그는 `logback-access-dev.xml`의 `ConsoleAppender` + `LogstashAccessEncoder`), 인프라의 **Grafana Alloy** 에이전트가 Docker socket으로 컨테이너 stdout을 수집해 Grafana Cloud Loki로 전송한다. 시스템 메트릭은 Alloy가 node-exporter를 scrape해 Grafana Cloud Mimir로 push한다. 운영자는 Grafana Cloud의 Grafana UI에서 로그·메트릭을 조회한다 (self-hosted Kibana/Grafana/Prometheus 없음).
+dev 프로파일의 로그는 더 이상 Logstash로 직접 TCP 송신하지 않는다. logback은 **stdout에 JSON 라인**으로 출력하며(`logback-spring.xml`의 `ConsoleAppender` + `LogstashEncoder`, access 로그는 `logback-access-dev.xml`의 `ConsoleAppender` + `LogstashAccessEncoder`), 인프라의 **Grafana Alloy** 에이전트가 Docker socket으로 컨테이너 stdout을 수집해 Grafana Cloud Loki로 전송한다. 시스템 메트릭은 Alloy가 node-exporter를 scrape해 Grafana Cloud Mimir로 push한다. **앱 레벨 메트릭**(JVM/Spring)은 Alloy가 `spring-app` replica별 `8081/prometheus`를 scrape → allow-list relabel → Mimir로 push한다(아래 `/prometheus` 참조). 운영자는 Grafana Cloud의 Grafana UI에서 로그·메트릭을 조회한다 (self-hosted Kibana/Grafana/Prometheus 없음).
 
 - 앱 로그/access 로그는 JSON의 `logType` 필드(`app-log`/`access-log`)로 구분되며 Loki에서 `log_type` 라벨로 승격된다.
 - `requestId`·`requestPlayerId` 같은 MDC 필드는 high-cardinality이므로 라벨로 올리지 않고 JSON 본문에 남긴다 (LogQL `| json | requestId="X"`로 사후 필터).

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
 	implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+	runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.23")
 	testImplementation("io.kotest:kotest-assertions-core:5.8.1")

--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/security/ManagementSecurityConfiguration.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/security/ManagementSecurityConfiguration.kt
@@ -1,0 +1,35 @@
+package ilpak.nomat.infrastructure.security
+
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * 관리(actuator) 전용 SecurityFilterChain.
+ *
+ * dev 프로파일에서 actuator는 전용 관리 포트(8081)로 분리되며, 이 포트는 내부 네트워크
+ * (컨테이너 내부 healthcheck·nginx reverse proxy·Alloy scrape) 전용이라 인증을 요구하지 않는다.
+ * 메인 체인의 OAuth2/STATELESS/Http403ForbiddenEntryPoint가 적용되면 Alloy가 403을 맞으므로
+ * `EndpointRequest.toAnyEndpoint()`로 매칭되는 별도 permitAll 체인을 둔다.
+ *
+ * 메인 [SecurityConfiguration.filterChain]보다 먼저 매칭되도록 @Order를 지정한다.
+ */
+@Configuration
+@Profile("!test")
+class ManagementSecurityConfiguration {
+
+    @Bean
+    @Order(1)
+    fun managementFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http.securityMatcher(EndpointRequest.toAnyEndpoint())
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .build()
+    }
+}

--- a/back/src/main/kotlin/ilpak/nomat/infrastructure/security/SecurityConfiguration.kt
+++ b/back/src/main/kotlin/ilpak/nomat/infrastructure/security/SecurityConfiguration.kt
@@ -49,6 +49,6 @@ class SecurityConfiguration(
     }
 
     companion object {
-        val permittedUrls = setOf("/login/**", "/html/**", "/health/**", "/info/**", "/ws/**")
+        val permittedUrls = setOf("/login/**", "/html/**", "/ws/**")
     }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -6,13 +6,17 @@ management:
         health: health
         info: info
       exposure:
-        include: health, info
+        include: health, info, prometheus
   endpoint:
     health:
       show-components: always
       show-details: when-authorized
       cache:
         time-to-live: 10s
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: false
 app:
   health:
     pubsub:
@@ -96,6 +100,9 @@ logging:
 ---
 server:
   forward-headers-strategy: framework
+management:
+  server:
+    port: 8081
 spring:
   config:
     activate:

--- a/back/src/test/kotlin/ilpak/nomat/health/in/PrometheusEndpointIntegrationTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/health/in/PrometheusEndpointIntegrationTest.kt
@@ -1,0 +1,39 @@
+package ilpak.nomat.health.`in`
+
+import ilpak.nomat.infrastructure.integration.IntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.WebTestClient
+
+// @SpringBootTest는 기본적으로 metrics export를 끄지만(management.defaults.metrics.export.enabled=false),
+// @IntegrationTest 공용 컨텍스트에서 해당 property를 true로 켜므로 prometheus endpoint가 노출된다.
+// (@AutoConfigureObservability를 쓰면 컨텍스트 캐시 키가 갈라져 ES 컨테이너가 중복 기동되므로 사용하지 않는다.)
+@IntegrationTest
+class PrometheusEndpointIntegrationTest(
+    @Autowired private val webTestClient: WebTestClient,
+) {
+
+    @Test
+    fun `prometheus_JVM과 HTTP 요청 메트릭을 exposition 포맷으로 노출한다`() {
+        // http_server_requests 메트릭은 한 번이라도 요청이 처리된 뒤에야 등록되므로 먼저 호출한다
+        webTestClient.get().uri("/health")
+            .exchange()
+            .expectStatus().isOk
+
+        webTestClient.get().uri("/prometheus")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java)
+            .value { body ->
+                check("jvm_memory_used_bytes" in body) {
+                    "prometheus 본문에 jvm_memory_used_bytes 메트릭이 없습니다"
+                }
+                check("http_server_requests" in body) {
+                    "prometheus 본문에 http_server_requests 메트릭이 없습니다"
+                }
+                check("http_server_requests_seconds_bucket" !in body) {
+                    "히스토그램 버킷이 비활성화되어야 하는데 http_server_requests_seconds_bucket 시계열이 존재합니다"
+                }
+            }
+    }
+}

--- a/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/IntegrationTest.kt
+++ b/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/IntegrationTest.kt
@@ -4,6 +4,7 @@ import ilpak.nomat.NomatApplication
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestExecutionListeners
 import org.springframework.test.context.TestPropertySource
@@ -19,6 +20,7 @@ import java.lang.annotation.Inherited
     classes = [NomatApplication::class, TestConfiguration::class],
     properties = ["spring.main.allow-bean-definition-overriding=true"],
 )
+@AutoConfigureObservability
 @TestPropertySource(properties = ["spring.profiles.active=test", "app.room.reconnect-grace-period-seconds=2"])
 @EnableAutoConfiguration(exclude = [OAuth2ClientAutoConfiguration::class])
 @TestExecutionListeners(

--- a/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/IntegrationTestExecutionListener.kt
+++ b/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/IntegrationTestExecutionListener.kt
@@ -1,6 +1,10 @@
 package ilpak.nomat.infrastructure.integration
 
+import ilpak.nomat.playlist.out.document.PlaylistDocument
 import org.flywaydb.core.Flyway
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.data.elasticsearch.core.query.DeleteQuery
+import org.springframework.data.elasticsearch.core.query.Query
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.support.AbstractTestExecutionListener
@@ -16,5 +20,9 @@ class IntegrationTestExecutionListener : AbstractTestExecutionListener() {
 
         val redisTemplate = applicationContext.getBean(StringRedisTemplate::class.java)
         redisTemplate.connectionFactory?.connection?.use { it.serverCommands().flushAll() }
+
+        val elasticsearchOperations = applicationContext.getBean(ElasticsearchOperations::class.java)
+        elasticsearchOperations.delete(DeleteQuery.builder(Query.findAll()).build(), PlaylistDocument::class.java)
+        elasticsearchOperations.indexOps(PlaylistDocument::class.java).refresh()
     }
 }

--- a/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/TestConfiguration.kt
+++ b/back/src/test/kotlin/ilpak/nomat/infrastructure/integration/TestConfiguration.kt
@@ -1,11 +1,13 @@
 package ilpak.nomat.infrastructure.integration
 
 import ilpak.nomat.infrastructure.security.SecurityConfiguration
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Lazy
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -25,6 +27,19 @@ class TestConfiguration {
     @Bean
     fun authenticationFilter(): OncePerRequestFilter {
         return TestAuthenticationFilter()
+    }
+
+    // test 프로파일은 actuator를 메인 포트에 유지한다(포트 분리 없음).
+    // 운영의 ManagementSecurityConfiguration(@Profile("!test"))과 동일하게
+    // actuator endpoint를 permitAll하여 /health·/info·/prometheus를 무인증 접근 가능하게 한다.
+    @Bean
+    @Order(1)
+    fun managementFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http.securityMatcher(EndpointRequest.toAnyEndpoint())
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .build()
     }
 
     @Bean

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -19,7 +19,7 @@ data/         — 데이터 노드 (단독 Docker Compose: MySQL, ES, Redis, all
   alloy-config.alloy
 ```
 
-로그·메트릭은 self-hosted 백엔드(Kibana/Logstash/Prometheus/Grafana) 없이 **Grafana Cloud**로 전송한다. 각 노드의 **Grafana Alloy** 에이전트가 Docker socket으로 컨테이너 stdout을 수집해 Loki로, node-exporter를 scrape해 Mimir로 push한다. 운영자는 Grafana Cloud의 Grafana UI에서 조회한다.
+로그·메트릭은 self-hosted 백엔드(Kibana/Logstash/Prometheus/Grafana) 없이 **Grafana Cloud**로 전송한다. 각 노드의 **Grafana Alloy** 에이전트가 Docker socket으로 컨테이너 stdout을 수집해 Loki로, node-exporter를 scrape해 Mimir로 push한다. app 노드에서는 Alloy가 추가로 `spring-app`을 backend 네트워크에서 replica별로 scrape해 앱(JVM/Spring) 메트릭도 Mimir로 push한다. 운영자는 Grafana Cloud의 Grafana UI에서 조회한다.
 
 ## 배포
 
@@ -31,13 +31,14 @@ data/         — 데이터 노드 (단독 Docker Compose: MySQL, ES, Redis, all
 
 ### 네트워크
 
-- **app 스택**: `backend` overlay 네트워크로 spring-app ↔ nginx 연결. `observability` overlay로 alloy ↔ node-exporter scrape 격리
+- **app 스택**: `backend` overlay 네트워크로 spring-app ↔ nginx 연결. `observability` overlay로 alloy ↔ node-exporter scrape. 앱 메트릭 scrape를 위해 **alloy를 `backend`에도 합류**시켜 격벽을 **Alloy 한 방향으로 부분 개방**한다(`alloy.networks = [observability, backend]`). `spring-app`은 `observability`를 알지 못하므로 역방향 격리는 유지된다(앱 컨테이너가 침해돼도 관측망 도달 불가)
 - **data 스택**: `observability` bridge 네트워크로 alloy ↔ node-exporter 연결. Elasticsearch 등 나머지 서비스는 포트 매핑으로 외부 노출
 
 ### Nginx
 
 - `nomat-back_spring-app:8080`으로 리버스 프록시 (Swarm 서비스 디스커버리 사용)
 - `/ws` 경로는 WebSocket 업그레이드 헤더 추가
+- **actuator 관리 포트(8081) allow-list**: dev에서 actuator는 전용 관리 포트(8081)로 분리된다. nginx는 `upstream backend_mgmt`(`:8081`)로 `location = /info`만 공개 reverse proxy한다(버전 확인 통로). `/health`는 컨테이너 내부 healthcheck(`localhost:8081`) 전용, `/prometheus`는 Alloy scrape 전용 — 둘 다 nginx 미프록시이므로 공개 도달 불가(default-closed)
 
 ### Swarm config 업데이트 (Nginx / Alloy)
 
@@ -49,6 +50,7 @@ Docker Swarm config는 수정 시 키 값을 변경해야 적용된다. app 스�
 
 - 각 노드의 **Alloy** 에이전트가 Docker socket(`/var/run/docker.sock:ro`)으로 컨테이너 stdout을 tail → Grafana Cloud **Loki**로 전송. `discovery.docker`로 컨테이너 메타를 라벨링하고, spring-app JSON 로그의 `logType`/`level`만 라벨로 승격한다 (`requestId` 등 high-cardinality는 line content로 보존).
 - Alloy가 같은 노드의 `node-exporter:9100`을 scrape → Grafana Cloud **Mimir**로 remote_write. 메트릭에는 `node=app|data` external label이 붙는다.
+- **app 노드 앱 메트릭**: Alloy가 `backend` 네트워크에서 `discovery.docker`로 로컬 컨테이너를 열거하고 swarm service 라벨(`nomat-back_spring-app`)로 keep → replica별 타깃(컨테이너 이름을 `instance` 라벨로)으로 `<ip>:8081/prometheus`를 scrape. `prometheus.relabel "app_allowlist"`가 `__name__` 화이트리스트(`jvm_*`·`process_*`·`system_*`·`http_server_requests*`·`hikaricp_*`·`logback_events*`·`tomcat_*`)로 송신을 제한해 Mimir 10k active series 예산을 하드캡한다. replica별 `instance`로 두 replica를 개별 식별한다(`jvm_memory_used_bytes{node="app"}`).
 - app 노드 Alloy는 `deploy.mode: global`(Swarm 노드당 1개), data 노드 Alloy는 단독 compose 컨테이너.
 
 ### 환경변수
@@ -60,4 +62,4 @@ Docker Swarm config는 수정 시 키 값을 변경해야 적용된다. app 스�
 ### Spring App 배포 전략
 
 - 2 replicas, rolling update (parallelism: 1, start-first) — 무중단 배포
-- 헬스체크: `http://localhost:8080/health` (30초 간격, 60초 시작 대기)
+- 헬스체크: `http://localhost:8081/health` (관리 포트, 컨테이너 내부 직접 호출 — nginx 우회. 30초 간격, 60초 시작 대기)

--- a/infra/app/alloy-config.alloy
+++ b/infra/app/alloy-config.alloy
@@ -107,3 +107,61 @@ prometheus.scrape "node_exporter" {
   job_name   = "node-exporter"
   forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }
+
+// ── 앱 메트릭: spring-app(replicas) scrape → allow-list → Mimir ───────────────
+// alloy는 backend 네트워크에도 합류해 있어(compose) spring-app 컨테이너에 도달 가능.
+// discovery.docker(로그 수집과 공유)로 로컬 노드 컨테이너를 열거하고, swarm service
+// 라벨로 spring-app만 keep → replica별 타깃(per-replica instance)으로 8081/prometheus를 scrape.
+
+discovery.relabel "spring_app" {
+  targets = discovery.docker.containers.targets
+
+  // nomat-back_spring-app 컨테이너만 선택
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_swarm_service_name"]
+    regex         = "nomat-back_spring-app"
+    action        = "keep"
+  }
+  // backend 오버레이 네트워크의 타깃만 유지(네트워크당 1개 타깃으로 중복 제거, 도달 가능 IP)
+  rule {
+    source_labels = ["__meta_docker_network_name"]
+    regex         = "backend"
+    action        = "keep"
+  }
+  // 컨테이너 IP + 관리 포트(8081)로 scrape 주소 합성 (컨테이너는 포트를 publish하지 않음)
+  rule {
+    source_labels = ["__meta_docker_network_ip"]
+    regex         = "(.+)"
+    replacement   = "$1:8081"
+    target_label  = "__address__"
+  }
+  // replica별 식별: 컨테이너 이름을 instance 라벨로 (앞 슬래시 제거)
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/?(.*)"
+    target_label  = "instance"
+  }
+  // actuator prometheus endpoint 경로
+  rule {
+    target_label = "__metrics_path__"
+    replacement  = "/prometheus"
+  }
+}
+
+prometheus.scrape "spring_app" {
+  targets    = discovery.relabel.spring_app.output
+  job_name   = "spring-app"
+  forward_to = [prometheus.relabel.app_allowlist.receiver]
+}
+
+// 카디널리티 하드캡: __name__ 화이트리스트로 송신 메트릭 제한 (Decision 5).
+// 앱에서 히스토그램을 켜거나 URI가 새도 Mimir 입구에서 차단되어 10k 예산 방어.
+prometheus.relabel "app_allowlist" {
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+  rule {
+    source_labels = ["__name__"]
+    regex         = "(jvm|process|system|hikaricp|logback_events|tomcat)_.*|http_server_requests.*|up"
+    action        = "keep"
+  }
+}

--- a/infra/app/compose.yml
+++ b/infra/app/compose.yml
@@ -14,7 +14,7 @@ services:
         failure_action: rollback
         order: start-first
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -43,7 +43,7 @@ services:
     networks:
       - backend
     configs:
-      - source: nginx_conf-4
+      - source: nginx_conf-5
         target: /etc/nginx/nginx.conf
   alloy:
     image: grafana/alloy:v1.10.0
@@ -63,10 +63,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     configs:
-      - source: alloy_config-2
+      - source: alloy_config-3
         target: /etc/alloy/config.alloy
     networks:
       - observability
+      - backend
   node-exporter:
     image: prom/node-exporter:latest
     networks:
@@ -80,7 +81,7 @@ networks:
     driver: overlay
 configs:
   # config 파일은 수정이 필요하면, config key 값을 변경해야 적용 됨
-  nginx_conf-4:
+  nginx_conf-5:
     file: ./nginx.conf
-  alloy_config-2:
+  alloy_config-3:
     file: ./alloy-config.alloy

--- a/infra/app/nginx.conf
+++ b/infra/app/nginx.conf
@@ -6,9 +6,22 @@ http {
         server nomat-back_spring-app:8080;
     }
 
+    # actuator 관리 포트(8081) — 공개로는 /info만 allow-list (/health·/prometheus는 미프록시)
+    upstream backend_mgmt {
+        server nomat-back_spring-app:8081;
+    }
+
     server {
         listen 80;
         server_name api.dev.nomat.live;
+
+        # 배포 버전 확인 통로: 관리 포트의 /info만 공개로 reverse proxy
+        location = /info {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass http://backend_mgmt;
+        }
 
         location /ws {
             proxy_pass http://backend;

--- a/openspec/changes/expose-application-metrics/.openspec.yaml
+++ b/openspec/changes/expose-application-metrics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/expose-application-metrics/README.md
+++ b/openspec/changes/expose-application-metrics/README.md
@@ -1,0 +1,3 @@
+# expose-application-metrics
+
+JVM·Spring Boot 애플리케이션 메트릭을 Actuator `prometheus` endpoint로 노출하고, Grafana Alloy가 `spring-app`을 replica별로 scrape하여 Grafana Cloud Mimir로 push한다. actuator를 전용 관리 포트(dev 프로파일 `8081`)로 분리해 공개 ingress 표면에서 격리하고, Alloy metric allow-list로 시계열 카디널리티를 하드캡한다. 직전 `replace-elk-with-grafana-cloud`가 Non-Goal로 남긴 앱 레벨 메트릭 사각지대를 닫는 후속 변경.

--- a/openspec/changes/expose-application-metrics/design.md
+++ b/openspec/changes/expose-application-metrics/design.md
@@ -1,0 +1,146 @@
+# Design — expose-application-metrics
+
+## Context
+
+직전 변경 `replace-elk-with-grafana-cloud`는 메트릭 경로를 "Alloy가 node-exporter scrape → Mimir remote_write"로 확정하면서, 앱 레벨 메트릭(JVM/Spring)은 명시적으로 후속으로 미뤘다. 본 변경은 그 후속이다. 탐색 과정에서 단순 endpoint 노출이 아니라 **네 개의 인프라 경계 결정**이 필요함이 드러났고, 아래 Decision으로 확정한다.
+
+현재 토폴로지 (앱 노드, 단일 Swarm 노드로 운영):
+
+```
+backend overlay                    observability overlay
+┌──────────────────────┐          ┌──────────────────────────┐
+│ spring-app (replicas:2)│   격벽   │ alloy (global) +sock+creds │
+│   :8080  nginx :80host │  ←───→  │ node-exporter :9100        │
+└──────────────────────┘          └──────────────────────────┘
+```
+
+- `spring-app`은 `backend`에만, `alloy`/`node-exporter`는 `observability`에만 → 현재 Alloy는 앱에 도달할 경로가 없다
+- actuator `base-path: /`, nginx `location /`가 전부 `spring-app:8080`으로 프록시 → `prometheus`를 켜면 공개 도메인으로 노출
+- Spring Security(`SecurityConfiguration.kt`): `permittedUrls = /login/**, /html/**, /health/**, /info/**, /ws/**`, 나머지 `authenticated()`
+- 버전 확인 통로: CI `GIT_COMMIT=github.sha` → Dockerfile build-arg → `buildInfo()` → 공개 `GET /info`의 `build.commit` (실동작, 상시 운영 통로)
+
+## Goals / Non-Goals
+
+**Goals**
+- JVM·Spring Boot 메트릭을 Actuator `prometheus` endpoint로 노출하고 Alloy가 replica별 scrape
+- `prometheus` endpoint를 공개 ingress 표면에서 격리
+- Grafana Cloud Free 10k active series 한도 안에서 안전한 카디널리티 유지
+
+**Non-Goals**
+- 커스텀 비즈니스 메트릭(`@Timed`, `MeterRegistry` 직접 사용) 추가 — 본 변경은 기본 Micrometer 메트릭만 노출
+- 대시보드·알림 룰 정의 — Grafana Cloud에서 운영 작업으로 별도 작성
+- `front/` 메트릭, `data/` 노드 앱 메트릭(앱이 없음)
+
+## Decision 1 — Alloy가 `backend` 네트워크에 합류해 pull scrape (격벽 부분 개방)
+
+`infra/CLAUDE.md:34`의 "`observability` overlay로 alloy ↔ node-exporter scrape 격리"는 의도된 설계다. 그러나 **pull이든 push든 메트릭은 어딘가에서 네트워크를 공유**해야 하므로, 격리를 유지한 채 scrape할 방법은 없다. 선택지는 "누가 격벽을 넘느냐":
+
+| 방향 | 격벽을 넘는 주체 | 평가 |
+|---|---|---|
+| **A. alloy → backend (pull)** | alloy에 `backend` 추가 | 표준 Prometheus 토폴로지. alloy는 이미 `docker.sock`+Cloud creds 보유(최고 권한) → 한계 노출 최소. **채택** |
+| B. app → observability (pull) | spring-app(×2)에 `observability` 추가 | 방향이 거꾸로(앱이 관측망을 앎), replica마다 추가 오버레이 |
+| C. app → alloy (push, OTLP) | app→alloy 경로 필요 | push도 공유망 불가피(B와 동일 방향) + 앱 OTLP 설정 부담만 증가 |
+
+**채택: A.** `alloy.networks = [observability, backend]`. `spring-app`은 `observability`를 알지 못하므로 역방향 격리는 유지된다(앱 컨테이너가 침해돼도 관측망 도달 불가).
+
+## Decision 2 — `discovery.docker` 재사용으로 replica별 타깃 + per-replica `instance` 라벨
+
+`spring-app`은 `replicas: 2`다. scrape 타깃 선정 방식:
+
+| 방식 | 결과 |
+|---|---|
+| `spring-app:8081` (VIP static) | 매 scrape마다 replica 라운드로빈 → 두 replica 메트릭이 한 시계열에 섞임 ✗ |
+| `tasks.spring-app` (DNS A) | 전 클러스터 task IP 반환 → 단일노드 OK, 멀티노드면 global alloy가 전부 중복 scrape △ |
+| **`discovery.docker`** | **로컬 노드 컨테이너만** 열거 → replica별 타깃, `container_name`→`instance`. 멀티노드여도 노드별 alloy가 자기 replica만 scrape ✓ |
+
+**채택: `discovery.docker`.** 이미 로그 수집(`loki.source.docker`)에 쓰는 메커니즘을 그대로 재사용한다. `discovery.relabel`로 `__meta_docker_container_label_com_docker_swarm_service_name == "nomat-back_spring-app"`만 keep, `__meta_docker_container_name`을 `instance`로, `__address__`를 `<ip>:8081`로 합성. 이로써 걸림돌(network)과 걸림돌(replica discovery)이 한 번에 해결되고, 미래 멀티노드 확장에도 노드-로컬 scrape로 자동 정합한다.
+
+## Decision 3 — `management.server.port` 분리(2-B) + 관리 전용 `SecurityFilterChain`
+
+`prometheus`를 같은 8080 포트에 켜면 두 요구가 충돌한다: ① Alloy(무인증 내부 에이전트)가 scrape 가능해야 함, ② 공개 인터넷은 못 읽어야 함. 같은 공개 포트에서는 permitAll(→ 공개 유출) 또는 authenticated(→ Alloy 403) 중 하나가 된다.
+
+| 옵션 | 평가 |
+|---|---|
+| 2-A. 같은 8080 + permit + nginx에서 `/prometheus` deny | 국소적이나 **부정 보안 모델**(blocklist 의존). 한 경로라도 빠뜨리면 유출 |
+| **2-B. `management.server.port: 8081`로 actuator 전체 이동** | actuator를 공개 표면에서 **구조적 분리**(default-closed). **채택** |
+
+**채택: 2-B.** 단, 두 가지 핵심 보완:
+
+1. **관리 전용 `SecurityFilterChain` 필수.** 관리 포트를 분리해도 보안을 안 주면 메인 체인(OAuth2 login·STATELESS·`Http403ForbiddenEntryPoint`)이 적용돼 **Alloy가 403**을 맞는다. `http.securityMatcher(EndpointRequest.toAnyEndpoint())` → `permitAll`인 별도 빈을 둔다(관리 포트는 내부 전용이므로 안전). 메인 `filterChain`은 무변경, `permittedUrls`에서 `/health/**`·`/info/**`만 제거.
+
+2. **분리는 dev 프로파일 한정.** `management.server.port: 8081`을 dev 프로파일에만 둔다. 이유: `redis-pubsub-health`의 기존 Testcontainers `WebTestClient /health` 통합 테스트는 메인 포트 기준이라, 전역으로 포트를 분리하면 테스트가 깨진다. 포트 분리는 운영(dev/EC2) 관심사이고, `local`/`test`는 메인 포트에 actuator를 유지해 기존 동작·테스트를 보존한다.
+
+`base-path`는 `/` 그대로 둔다(관리 포트의 루트 = `/health`, `/info`, `/prometheus`). 공개 경로를 안정적으로 유지하기 위해 내부 경로를 바꾸지 않는다.
+
+## Decision 4 — 공개 표면에는 `/info`만 allow-list, `/health`·`/prometheus`는 비공개
+
+2-B는 actuator **전체**(`/info`·`/health`·`/prometheus`)를 8081로 옮긴다. 이 중 **공개 ingress로 노출할 것은 `/info` 하나뿐**이다:
+
+- **`/info`**: 개발자 배포 버전 확인(`build.commit`)의 상시 외부 통로 → 공개 필요
+- **`/health`**: Swarm 컨테이너 헬스체크가 **컨테이너 내부에서 `localhost:8081`로 직접** 호출하며 nginx를 거치지 않는다 → **공개 노출 불필요**. 공개하지 않으면 `components.redisPubSub.status`·503 타이밍 등 내부 상태가 인터넷에 새지 않아 표면이 줄어든다
+- **`/prometheus`**: Alloy만 내부에서 scrape → 비공개
+
+**해법:** nginx가 `/info`만 관리 포트로 명시적 reverse proxy한다. `/health`는 컨테이너 내부 healthcheck 전용이라 nginx 미프록시.
+
+```
+nginx:80
+  location /         → backend(8080, 앱)         # actuator 없음
+  location = /info   → backend_mgmt(8081)/info    # 버전 확인 통로 (유일한 공개 actuator)
+  (그 외 actuator      미프록시)                   # /health·/prometheus 공개 도달 불가
+
+컨테이너 내부:  healthcheck curl → localhost:8081/health   # nginx 우회, 내부 전용
+Alloy(backend): scrape → spring-app:8081/prometheus        # nginx 우회, 내부 전용
+```
+
+- 개발자는 `curl https://api.dev.nomat.live/info`를 **그대로** 사용 — 공개 URL·동작 불변
+- **2-A의 deny와 방향이 반대**: 2-A는 blocklist(`/prometheus` deny, 빠뜨리면 유출), 2-B는 **allow-list**(명시한 `/info`만 공개, 나머지는 기본 차단). default-closed라 `/health`·`/prometheus`가 구조적으로 안전
+- nginx가 공개 경로와 내부 경로/포트를 디커플링 → 향후 내부 path가 바뀌어도 공개 URL 안정
+
+## Decision 5 — 카디널리티 가드: 히스토그램 기본 OFF + Alloy metric allow-list (하드캡)
+
+측정: 라우트 템플릿 ≈ 20개(모두 `@PathVariable`로 바운드), 히스토그램 설정 없음(기본값 `_bucket` 미생성). 추정 시계열:
+
+```
+node-exporter(app) ~700 + node-exporter(data) ~700
++ spring micrometer ~300-400/replica × 2 ≈ ~700-800
+= 총 ≈ 2,100 / 10,000   (헤드룸 ~8k, 현재 형태는 안전)
+```
+
+위험은 "당장 초과"가 아니라 **풋건**이다:
+- ① `percentiles-histogram.http.server.requests=true` 한 줄 → `_bucket` 폭증(≈ +2,400 시계열, 사용량 2배). p99 대시보드 만들려다 흔히 켬
+- ② 새 엔드포인트가 path에 UUID/이메일을 직접 박으면 URI 카디널리티 무한 증식
+- ③ replica 선형 증가(대당 ≈ +350)
+
+**가드(채택):**
+1. `management.metrics.distribution.percentiles-histogram.http.server.requests: false` 명시 — ①을 설정으로 고정. p99가 필요하면 client-side `percentiles=[0.95,0.99]`(조합당 ~2 시계열)로 저렴하게
+2. **Alloy `prometheus.relabel` allow-list = 비용 하드캡.** `__name__` keep 화이트리스트(`jvm_*`, `process_*`, `system_*`, `http_server_requests*`, `hikaricp_*`, `logback_events*`, `tomcat_*` 등)로 송신 메트릭을 제한. 앱에서 누가 히스토그램을 켜거나 URI가 새도 **Mimir 입구에서 차단**되어 10k 예산이 구조적으로 방어됨. 이 relabel은 Decision 2의 scrape 블록에 1단계로 부착(위치가 이미 정해짐)
+3. URI 템플릿화 규율을 `CLAUDE.md`에 부기(unbounded path 금지)
+4. 앱 메트릭 시계열 예산 ≈ 1k 명문화
+
+## Spec 영향 (기존 capability 수정)
+
+2-B가 actuator 노출 포트·보안 규칙을 바꾸므로 두 기존 spec을 수정한다. 두 capability의 **공개 동작 계약은 보존**하고, 내부 구현(포트·체인) 기술만 갱신한다.
+
+- `deployed-version-info`: 공개 `GET /info` 무인증 200 + `build.*` 계약 **보존**. 시나리오의 "`/info/**` permit 규칙" → "관리 `SecurityFilterChain` + nginx reverse proxy(dev)"로 갱신
+- `redis-pubsub-health`: `redisPubSub` 컴포넌트 노출·DOWN 시 503·Testcontainers 테스트(메인 포트) 계약 **보존**. compose healthcheck `localhost:8080/health` → `localhost:8081/health`, 인증 면제 `/health/**` → 관리 체인으로 갱신
+
+## DB / ES / Kafka / Redis
+
+- DB 스키마: 변경 없음 (Flyway 마이그레이션 없음)
+- Elasticsearch 매핑·Debezium CDC: 변경 없음
+- Kafka 토픽: 해당 없음
+- Redis Pub/Sub 채널: 변경 없음 (`health:pubsub:*` 동작 동일, `/health` 노출 포트만 8081로 이동)
+
+## Decision 8 — 롤백
+
+단일 PR로 배포하고, 문제 시 `git revert` 후 `infra/app` 재배포(`docker stack deploy`)로 원복한다. 세부:
+1. `application.yml`에서 `management.server.port`·`prometheus` exposure 원복 시 actuator가 8080으로 복귀 → `redis-pubsub-health`/`deployed-version-info` 기존 동작 자동 복원
+2. `infra/app/compose.yml`·`nginx.conf`·`alloy-config.alloy` revert + Swarm config 키 원복(`alloy_config`·`nginx_conf`)
+3. Mimir에 쌓인 앱 시계열은 14일 보관 후 자연 만료 — 별도 정리 불필요
+4. Alloy의 `backend` 합류만 부분 revert해도 scrape는 즉시 중단됨(빠른 안전장치)
+
+## Risks
+
+- **관리 포트 바인드 주소**: `management.server.port` 분리 시 관리 connector가 모든 인터페이스에 바인드되어야 Alloy가 오버레이로 도달 가능. `management.server.address`를 localhost로 제한하지 않도록 주의 (검증 태스크 포함)
+- **관리 체인 우선순위**: 관리 `SecurityFilterChain`이 메인 체인보다 먼저 매칭되도록 `EndpointRequest` matcher + 적절한 `@Order` 필요. 잘못되면 Alloy 403 또는 앱 보안 약화
+- **healthcheck 전환 타이밍**: compose healthcheck를 8081로 바꾸는 시점과 앱이 8081을 listen하기 시작하는 배포가 정합해야 함. `start_period: 60s`가 흡수하나, 롤링 업데이트 중 한 replica가 구버전(8080 health)일 수 있음 → start-first 업데이트 순서로 흡수

--- a/openspec/changes/expose-application-metrics/proposal.md
+++ b/openspec/changes/expose-application-metrics/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+직전 변경 `replace-elk-with-grafana-cloud`는 시스템 레벨 메트릭(node-exporter)만 Grafana Cloud Mimir로 보냈고, **JVM·Spring Boot 애플리케이션 메트릭(heap, GC, 스레드, HTTP 응답시간, DB 커넥션 풀 등)은 의도적으로 Non-Goal로 남겼다** (해당 변경 `design.md`의 "JVM/Spring Boot 메트릭 노출 — 후속 변경 후보", `tasks.md` 10.6). 그 결과 현재 상태는:
+
+1. `spring-boot-starter-actuator`는 이미 의존성에 있으나 **`micrometer-registry-prometheus`가 없어 `prometheus` endpoint 자체가 동작하지 않는다**
+2. `management.endpoints.web.exposure.include`는 `health, info`만 — `prometheus` 미노출
+3. Alloy는 `node-exporter`만 scrape → **앱 내부 상태가 통째로 관측 사각지대**
+
+인시던트 시 "컨테이너 CPU·메모리는 정상인데 응답이 느리다"는 상황에서 GC 폭주·스레드 고갈·HikariCP 커넥션 풀 고갈·특정 엔드포인트 지연을 구분할 수 없다. 본 변경은 앱 레벨 메트릭을 Actuator `prometheus` endpoint로 노출하고 Alloy가 scrape하도록 하여 이 사각지대를 닫는다.
+
+단순 "endpoint 한 줄 켜기"가 아니라 세 개의 인프라 경계 결정이 따른다: (a) Alloy와 `spring-app`이 **서로 다른 오버레이 네트워크**에 격리되어 있어 scrape 경로가 없고, (b) actuator `base-path: /` + nginx `location /`가 `prometheus`를 **공개 도메인으로 노출**하며, (c) Grafana Cloud Free tier **10k active series** 한도에서 `http_server_requests` 히스토그램·replica 배수가 시계열을 폭증시킬 수 있다. 본 제안은 이 세 결정을 설계로 확정한다 (`design.md` Decision 1~4 참조).
+
+## What Changes
+
+### back/
+- `back/build.gradle.kts`: `runtimeOnly("io.micrometer:micrometer-registry-prometheus")` 추가 (Spring Boot BOM이 버전 관리 — 명시 버전 없음)
+- `back/src/main/resources/application.yml`:
+  - `management.endpoints.web.exposure.include`에 `prometheus` 추가 (`health, info, prometheus`)
+  - **dev 프로파일 한정** `management.server.port: 8081` 추가 — actuator 전체를 전용 관리 포트로 분리. `local`/`test` 프로파일은 메인 포트 유지 (기존 테스트·로컬 동작 불변)
+  - `management.metrics.distribution.percentiles-histogram.http.server.requests: false` 명시 — 히스토그램 버킷 미생성 의도 고정 (카디널리티 가드)
+  - `management.endpoint.health`의 `show-components: always` 유지 (replica per-component status 노출 — `redis-pubsub-health` 계약 보존)
+- `back/src/main/kotlin/ilpak/nomat/infrastructure/security/`: **관리 전용 `SecurityFilterChain` 빈 신규** — `EndpointRequest.toAnyEndpoint()`로 매칭, `permitAll` + csrf disable + STATELESS. 관리 포트는 내부 전용이므로 인증 없이 Alloy·nginx가 접근 가능. 기존 `SecurityConfiguration.filterChain`(앱 요청용)은 무변경, 단 `permittedUrls`에서 `/health/**`·`/info/**`는 제거(actuator가 더 이상 메인 포트에 없음)
+- `back/CLAUDE.md`: observability/운영 엔드포인트 섹션에 actuator 관리 포트(8081)·`prometheus` endpoint·Micrometer 메트릭 부기
+
+### infra/
+- `infra/app/compose.yml`:
+  - `alloy` 서비스의 `networks`에 `backend` 추가 (`[observability, backend]`) — scrape를 위해 앱 네트워크 격벽을 의도적으로 부분 개방 (`design.md` Decision 1)
+  - `spring-app` `healthcheck`의 `curl` 대상을 `http://localhost:8081/health`로 변경 (관리 포트 분리 반영)
+  - `alloy_config-2` → `alloy_config-3` (Swarm config 키 증가)
+- `infra/app/alloy-config.alloy`:
+  - `discovery.docker` + `discovery.relabel`로 `nomat-back_spring-app` 컨테이너만 keep, replica별 container 이름을 `instance` 라벨로, `__address__`를 `<task_ip>:8081`로 합성, `metrics_path = /prometheus`
+  - `prometheus.scrape "spring_app"` 추가 → `prometheus.relabel` 경유 → `prometheus.remote_write.grafana_cloud`
+  - `prometheus.relabel "app_allowlist"` 추가: `__name__` keep 화이트리스트로 송신 메트릭 제한 (카디널리티 하드캡, `design.md` Decision 4)
+- `infra/app/nginx.conf`:
+  - `upstream backend_mgmt { server nomat-back_spring-app:8081; }` 추가
+  - `location = /info`만 `backend_mgmt`로 reverse proxy (공개 버전 확인 통로 보존). `/health`·`/prometheus`는 프록시 목록에 **포함하지 않음** → 공개 도달 불가 (allow-list/default-closed). `/health`는 컨테이너 내부 healthcheck(`localhost:8081`)가 nginx를 거치지 않고 직접 호출
+  - `nginx_conf-4` → `nginx_conf-5` (Swarm config 키 증가)
+- `infra/CLAUDE.md`: observability 흐름에 "Alloy가 `spring-app`을 backend 네트워크에서 replica별 scrape" 추가, 네트워크 격리 문구를 "부분 개방"으로 갱신, 관리 포트·nginx allow-list 명시
+
+### .github/workflows/
+- 변경 없음 — Mimir write 자격증명(`GRAFANA_CLOUD_MIMIR_*`, `GRAFANA_CLOUD_API_TOKEN`)은 직전 변경에서 이미 주입됨
+
+### front/
+- 영향 없음
+
+## Capabilities
+
+### New Capabilities
+- `application-metrics`: JVM·Spring Boot 애플리케이션 메트릭을 Actuator `prometheus` endpoint(전용 관리 포트)로 노출하고, Alloy가 replica별로 scrape하여 Grafana Cloud Mimir로 송신하되, 공개 ingress 표면에서 분리하고 시계열 카디널리티를 allow-list로 제한하는 능력
+
+### Modified Capabilities
+- `deployed-version-info`: `/info`가 메인 포트에서 **dev 관리 포트(8081)로 이동**하고, 공개 `GET /info`는 nginx reverse proxy를 통해 제공된다. 인증 면제 규칙이 메인 체인의 `/info/**` permit에서 **관리 전용 `SecurityFilterChain`(permitAll)**으로 이동. 공개 동작 계약(인증 없이 빌드 메타 200)은 보존
+- `redis-pubsub-health`: 컨테이너 헬스체크가 `http://localhost:8080/health` → **`http://localhost:8081/health`**(컨테이너 내부, nginx 우회)로 변경되고, `/health`가 dev 관리 포트에서 제공된다. **공개 ingress로는 노출하지 않는다**(nginx 미프록시). 인증 면제가 `/health/**` permit → 관리 체인으로 이동. `redisPubSub` 컴포넌트 노출·503 의미·Testcontainers 테스트(메인 포트 유지) 계약은 보존
+
+## Impact
+
+- **서브프로젝트**: `back/`(build.gradle.kts·application.yml·security·CLAUDE.md), `infra/`(app: compose·alloy-config·nginx·CLAUDE.md). `front/`·`infra/data/` 영향 없음
+- **도메인 모듈**: 직접 변경 없음. `playlist`/`room`/`player`/`favoriteplaylist`/`auth` 로직 무변경 — 횡단 관심사(`infrastructure/security`)와 운영 설정만 변경
+- **헥사고날 계층**: `in`/`out`/`application` 변경 없음. 신규 도메인 빈·포트·어댑터 추가 없음. `infrastructure/security`에 관리 전용 `SecurityFilterChain` 빈 1개 추가
+- **DB 스키마**: 변경 없음 (Flyway 마이그레이션 없음)
+- **ES 매핑**: 변경 없음 (`PlaylistDocument` 무관, Debezium CDC 무관)
+- **Kafka 토픽**: 해당 없음
+- **Redis 키**: 변경 없음 (`health:pubsub:*` 채널 동작 무변경 — 노출 포트만 8081로 이동)
+- **의존성**: 추가 — `io.micrometer:micrometer-registry-prometheus`(runtimeOnly). 제거 없음
+- **외부 시스템**: Grafana Cloud Mimir에 앱 메트릭 시계열 추가 송신. 신규 외부 의존 없음 (기존 Mimir 재사용). Free tier 10k active series 한도 내 사용 가정 — 앱 메트릭 예산 ≈ 1k (`design.md` Decision 4)
+- **인프라 컨테이너 변화**: 컨테이너 수 변화 없음. `alloy`가 `backend` 네트워크에 추가 합류, `spring-app`이 8081 관리 포트를 추가 listen(내부 전용, 미발행)
+- **네트워크 경계**: `observability` ↔ `backend` 격리가 **Alloy 한 방향으로 부분 개방**됨 (Alloy→`spring-app:8081` scrape). `spring-app`은 `observability`를 알지 못함(역방향 격리 유지)
+- **운영 동작**:
+  - 메트릭: Alloy가 backend 네트워크에서 `spring-app` replica를 `discovery.docker`로 열거→ 각 8081/prometheus scrape → allow-list relabel → Mimir push. Grafana Cloud에서 `jvm_memory_used_bytes{node="app"}`, `http_server_requests_seconds_count` 등 조회 가능
+  - 공개 `/info`: nginx가 8081로 reverse proxy → 외부 동작 불변(개발자 버전 확인 통로 보존)
+  - 공개 `/health`·`/prometheus`: **도달 불가** (nginx 미프록시) — 관리 포트 내부 전용. `/health`는 컨테이너 내부 healthcheck(`localhost:8081`)·`/prometheus`는 Alloy만 접근
+  - replica별 `instance` 라벨로 두 replica를 개별 식별. replica 증가 시 시계열 선형 증가(대당 ≈ 350)
+- **롤백**: 단일 PR `git revert` + `infra/app` 재배포(`docker stack deploy`) + (필요 시) 관리 포트 분리 전 `application.yml`로 원복. Mimir에 쌓인 앱 시계열은 14일 보관 후 자연 만료. 자세한 절차는 `design.md` Decision 8

--- a/openspec/changes/expose-application-metrics/specs/application-metrics/spec.md
+++ b/openspec/changes/expose-application-metrics/specs/application-metrics/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: JVM·Spring Boot 메트릭을 Actuator prometheus endpoint로 노출
+
+시스템은 백엔드 애플리케이션의 JVM·Spring Boot 런타임 메트릭(heap/non-heap 메모리, GC, 스레드, 클래스 로딩, HTTP 요청, HikariCP 커넥션 풀, logback 이벤트 등)을 Spring Boot Actuator의 `prometheus` endpoint(Prometheus text exposition format)로 노출해야(SHALL) 한다. 메트릭 수집은 `micrometer-registry-prometheus`와 Actuator 기본 binder로 구성하며, 커스텀 비즈니스 메트릭은 본 능력의 범위가 아니다.
+
+#### Scenario: prometheus endpoint가 표준 포맷으로 메트릭 노출
+- **WHEN** 내부 클라이언트가 관리 포트의 `GET /prometheus`를 호출
+- **THEN** HTTP 200 + `text/plain; version=0.0.4` 계열 Prometheus exposition 포맷 본문을 반환해야 한다
+- **AND** 본문에 `jvm_memory_used_bytes`, `jvm_gc_*`, `http_server_requests_seconds_count`, `hikaricp_connections` 계열 메트릭이 포함되어야 한다
+
+#### Scenario: management exposure에 prometheus 포함
+- **WHEN** `application.yml`의 `management.endpoints.web.exposure.include`를 검사
+- **THEN** `prometheus`가 포함되어 있어야 한다
+
+#### Scenario: micrometer-registry-prometheus 의존성 존재
+- **WHEN** `back/build.gradle.kts`의 `dependencies` 블록을 검사
+- **THEN** `io.micrometer:micrometer-registry-prometheus`가 선언되어 있어야 한다 (버전은 Spring Boot BOM 관리 — 명시 버전 없음)
+
+### Requirement: 메트릭 endpoint는 전용 관리 포트에서만 제공되고 공개 ingress로 노출되지 않음
+
+시스템은 운영(dev) 환경에서 actuator를 전용 관리 포트(`management.server.port`)로 분리하고, `prometheus` endpoint를 **공개 ingress(nginx)로 프록시하지 않아야**(MUST NOT) 한다. `prometheus`는 내부 네트워크의 Alloy만 접근 가능해야 한다.
+
+#### Scenario: dev 프로파일에서 관리 포트 분리
+- **WHEN** dev 프로파일의 `application.yml` 관리 설정을 검사
+- **THEN** `management.server.port`가 메인 서버 포트(8080)와 다른 전용 포트로 설정되어 있어야 한다
+- **AND** `local`/`test` 프로파일에는 관리 포트 분리가 적용되지 않아야 한다 (기존 테스트·로컬 동작 보존)
+
+#### Scenario: 공개 도메인에서 prometheus 도달 불가
+- **WHEN** 외부 클라이언트가 `GET https://api.dev.nomat.live/prometheus`를 호출
+- **THEN** nginx가 해당 경로를 백엔드로 프록시하지 않으므로 메트릭 본문이 반환되지 않아야 한다 (404 또는 차단)
+
+#### Scenario: nginx가 prometheus를 reverse proxy하지 않음
+- **WHEN** `infra/app/nginx.conf`를 검사
+- **THEN** `prometheus` 경로를 백엔드로 프록시하는 `location` 블록이 존재하지 않아야 한다 (공개 actuator는 `/info`만 관리 포트로 allow-list, `/health`도 미프록시)
+
+### Requirement: Alloy가 spring-app을 replica별로 scrape하여 Mimir로 송신
+
+시스템은 Grafana Alloy가 `spring-app`의 각 replica를 개별 타깃으로 scrape하여 Grafana Cloud Mimir로 remote_write해야(SHALL) 한다. 두 replica의 메트릭은 서로 다른 `instance` 라벨로 식별 가능해야 하며, scrape는 VIP 라운드로빈으로 섞이지 않아야 한다.
+
+#### Scenario: Alloy가 backend 네트워크에서 replica를 열거
+- **WHEN** `infra/app/compose.yml`의 `alloy` 서비스 `networks`를 검사
+- **THEN** `backend` 네트워크가 포함되어 있어야 한다 (scrape 도달을 위한 격벽 부분 개방)
+- **AND** `alloy-config.alloy`에 `discovery.docker` 기반으로 `nomat-back_spring-app` 컨테이너만 선택하는 relabel이 정의되어 있어야 한다
+
+#### Scenario: replica별 instance 라벨
+- **WHEN** 운영자가 Grafana Cloud에서 `jvm_memory_used_bytes{node="app"}`를 조회
+- **THEN** 두 replica가 서로 다른 `instance` 라벨 값으로 각각 조회되어야 한다 (단일 시계열로 합쳐지지 않음)
+
+#### Scenario: 앱 메트릭이 Mimir로 송신됨
+- **WHEN** `alloy-config.alloy`를 검사
+- **THEN** `prometheus.scrape`가 `spring-app` replica를 대상으로 정의되고, `prometheus.remote_write`(`${GRAFANA_CLOUD_MIMIR_URL}`)로 forward되어야 한다
+
+### Requirement: 시계열 카디널리티는 히스토그램 OFF와 Alloy allow-list로 제한
+
+시스템은 Grafana Cloud Free tier(10k active series) 한도를 보호하기 위해 HTTP 요청 히스토그램 버킷을 기본 생성하지 않아야(MUST NOT) 하며, Alloy가 Mimir로 송신하는 메트릭을 이름 화이트리스트로 제한해야(MUST) 한다.
+
+#### Scenario: http_server_requests 히스토그램 버킷 미생성
+- **WHEN** `application.yml`의 metrics distribution 설정을 검사
+- **THEN** `management.metrics.distribution.percentiles-histogram.http.server.requests`가 `false`로 명시되어 있어야 한다
+- **AND** `prometheus` endpoint 응답에 `http_server_requests_seconds_bucket` 시계열이 존재하지 않아야 한다
+
+#### Scenario: Alloy metric allow-list 하드캡
+- **WHEN** `alloy-config.alloy`를 검사
+- **THEN** `spring-app` scrape 파이프라인에 `__name__` keep 화이트리스트(`jvm_*`, `process_*`, `system_*`, `http_server_requests*`, `hikaricp_*`, `logback_events*`, `tomcat_*` 등)로 송신 메트릭을 제한하는 `prometheus.relabel` 단계가 존재해야 한다
+- **AND** 화이트리스트에 없는 메트릭은 Mimir로 송신되지 않아야 한다 (앱에서 의도치 않은 메트릭이 켜져도 예산 방어)
+
+### Requirement: 앱 코드는 메트릭을 외부로 직접 push하지 않음
+
+시스템은 메트릭을 **Alloy scrape(pull)** 경로로만 수집해야(MUST) 한다. 백엔드 애플리케이션 코드가 외부 monitoring backend(Mimir/Prometheus push gateway/OTLP collector 등)로 직접 push하지 않아야 한다. 이는 `observability-pipeline`의 "백엔드는 backend에 직접 push하지 않는다" 원칙과 일관된다.
+
+#### Scenario: 백엔드에 메트릭 직접 송신 코드 없음
+- **WHEN** `back/` 소스와 `application.yml`을 검사
+- **THEN** OTLP/Prometheus remote-write/push-gateway 등 외부 metrics backend로 직접 push하는 설정·코드가 존재하지 않아야 한다 (Actuator `prometheus` endpoint 노출만 존재)

--- a/openspec/changes/expose-application-metrics/specs/deployed-version-info/spec.md
+++ b/openspec/changes/expose-application-metrics/specs/deployed-version-info/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: 빌드 메타데이터 HTTP 노출
+시스템은 운영 중인 백엔드 인스턴스가 빌드된 git commit, branch, 빌드 시각, artifact 이름·버전을 HTTP 응답으로 노출해야(SHALL) 한다. 운영(dev) 환경에서 actuator는 전용 관리 포트로 분리되며, 공개 `GET /info`는 nginx reverse proxy를 통해 관리 포트로 라우팅된다. 공개 동작 계약(인증 없이 빌드 메타 200)은 포트 분리 이전과 동일하게 유지된다.
+
+#### Scenario: /info 엔드포인트 200 응답
+- **WHEN** 외부 클라이언트가 `GET https://api.dev.nomat.live/info`를 호출
+- **THEN** HTTP 200 응답을 반환해야 한다
+- **AND** 응답 JSON `build` 객체에 `artifact`, `name`, `version`, `time`, `commit`, `branch` 키가 모두 존재해야 한다
+
+#### Scenario: 공개 /info가 nginx를 통해 관리 포트로 라우팅
+- **WHEN** `infra/app/nginx.conf`를 검사
+- **THEN** `location = /info`가 관리 포트 upstream(`nomat-back_spring-app:8081`)으로 reverse proxy하도록 정의되어 있어야 한다
+- **AND** 공개 클라이언트 입장에서 요청 URL(`/info`)과 응답 동작은 포트 분리 이전과 동일해야 한다
+
+#### Scenario: 인증 없이 접근 가능
+- **WHEN** 인증되지 않은 클라이언트가 `/info`를 호출
+- **THEN** 관리 전용 `SecurityFilterChain`(`EndpointRequest.toAnyEndpoint()` permitAll)에 의해 401/403 없이 빌드 메타데이터를 반환해야 한다 (메인 체인의 `/info/**` permit 규칙은 더 이상 사용하지 않음)
+
+#### Scenario: 민감 정보 미노출
+- **WHEN** 응답을 검사
+- **THEN** 스택 트레이스, 내부 호스트 주소, 데이터베이스 접속 문자열, 환경변수 값(예: JWT_KEY) 등 민감 정보가 포함되지 않아야 한다
+
+### Requirement: Spring Boot Actuator 통합
+시스템은 빌드 메타데이터 노출을 Spring Boot Actuator의 `/info` 엔드포인트 규약에 맞춰 구현해야(MUST) 한다. 운영(dev) 환경에서 actuator endpoint는 `management.server.port`로 분리된 전용 포트에서 제공된다.
+
+#### Scenario: management exposure에 info 포함
+- **WHEN** `application.yml`의 `management.endpoints.web.exposure.include`를 검사
+- **THEN** `info`가 포함되어 있어야 한다
+
+#### Scenario: dev 환경에서 actuator가 관리 포트에서 서비스됨
+- **WHEN** dev 프로파일의 `application.yml` 관리 설정을 검사
+- **THEN** `management.server.port`가 메인 포트와 다른 전용 포트로 설정되어 있어야 한다
+- **AND** `/info`를 포함한 모든 actuator endpoint가 해당 관리 포트에서 제공되어야 한다 (`local`/`test` 프로파일은 메인 포트 유지)
+
+#### Scenario: BuildInfoContributor가 자동 동작
+- **WHEN** `springBoot { buildInfo() }` Gradle 태스크가 빌드 시 실행됨
+- **AND** `additionalProperties`로 `commit`, `branch`가 주입됨
+- **THEN** Spring Boot Actuator의 `BuildInfoContributor`가 자동으로 이 값을 `/info` 응답의 `build.*` 네임스페이스에 노출해야 한다
+
+#### Scenario: 신규 InfoContributor 빈 추가 없음
+- **WHEN** 본 변경의 코드 변경을 검사
+- **THEN** `org.springframework.boot.actuate.info.InfoContributor`를 구현하는 신규 빈이 추가되지 않아야 한다 (Actuator 기본 contributor만 사용)

--- a/openspec/changes/expose-application-metrics/specs/redis-pubsub-health/spec.md
+++ b/openspec/changes/expose-application-metrics/specs/redis-pubsub-health/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: /health 엔드포인트가 컨테이너 헬스체크와 직접 연결
+시스템은 Docker Swarm이 보는 `/health` 엔드포인트가 헬스 검증 결과를 그대로 반영해야(SHALL) 한다. 더미 응답은 허용되지 않는다. 운영(dev) 환경에서 actuator는 전용 관리 포트(`management.server.port`)로 분리되며, 컨테이너 헬스체크는 **컨테이너 내부에서 `localhost`의 관리 포트 `/health`를 직접** 호출한다(nginx 우회). `/health`는 **공개 ingress로 노출하지 않는다**. `local`/`test` 프로파일은 메인 포트를 유지한다.
+
+#### Scenario: Swarm healthcheck가 관리 포트의 /health를 호출
+- **WHEN** Docker Swarm healthcheck(`infra/app/compose.yml`의 `curl -f http://localhost:8081/health`)가 컨테이너 내부에서 `/health`를 호출
+- **THEN** 응답은 Spring Boot Actuator health endpoint 결과여야 한다 (즉, `redisPubSub` 컴포넌트 상태가 반영됨)
+- **AND** 헬스 검증이 DOWN이면 HTTP 503을 반환하여 Swarm이 컨테이너를 unhealthy로 마킹할 수 있어야 한다
+
+#### Scenario: /health는 공개 ingress로 노출되지 않음
+- **WHEN** `infra/app/nginx.conf`를 검사
+- **THEN** `/health`를 백엔드로 프록시하는 `location` 블록이 존재하지 않아야 한다 (공개 actuator는 `/info`만 allow-list)
+- **AND** 외부 클라이언트가 `GET https://api.dev.nomat.live/health`를 호출하면 헬스 결과가 반환되지 않아야 한다 (도달 불가)
+
+#### Scenario: 더미 always-ok 응답이 더 이상 존재하지 않음
+- **WHEN** 코드베이스를 검사
+- **THEN** 어떤 검사도 수행하지 않고 항상 `"ok"`를 반환하는 `/health` 핸들러가 존재하지 않아야 한다
+
+#### Scenario: 인증 없이 호출 가능
+- **WHEN** 인증되지 않은 클라이언트(예: Swarm healthcheck 컨테이너 내부 curl)가 `/health`를 호출
+- **THEN** 관리 전용 `SecurityFilterChain`(`EndpointRequest.toAnyEndpoint()` permitAll)에 의해 401/403 없이 헬스 검증 결과를 반환해야 한다 (메인 체인의 `/health/**` permit 규칙은 더 이상 사용하지 않음)

--- a/openspec/changes/expose-application-metrics/tasks.md
+++ b/openspec/changes/expose-application-metrics/tasks.md
@@ -1,0 +1,51 @@
+# Tasks — expose-application-metrics
+
+## 1. back/ — Micrometer 의존성 및 actuator 노출
+
+- [x] 1.1 `back/build.gradle.kts` `dependencies`에 `runtimeOnly("io.micrometer:micrometer-registry-prometheus")` 추가 (Spring Boot BOM이 버전 관리 — 명시 버전 없음)
+- [x] 1.2 `back/src/main/resources/application.yml` 기본 문서의 `management.endpoints.web.exposure.include`를 `health, info, prometheus`로 변경
+- [x] 1.3 `application.yml`에 `management.metrics.distribution.percentiles-histogram.http.server.requests: false` 명시 추가 (카디널리티 가드 — 히스토그램 버킷 미생성 의도 고정)
+- [x] 1.4 `application.yml` **dev 프로파일 문서**에 `management.server.port: 8081` 추가 (`local`/`test` 프로파일에는 추가하지 않음 — 메인 포트 유지)
+
+## 2. back/ — 관리 포트 보안
+
+- [x] 2.1 `infrastructure/security`에 관리 전용 `SecurityFilterChain` 빈 신규 추가: `http.securityMatcher(EndpointRequest.toAnyEndpoint())` → `permitAll`, csrf disable, STATELESS. 메인 체인보다 먼저 매칭되도록 `@Order` 지정. 기존 `SecurityConfiguration`과 동일하게 `@Profile("!test")` 적용. 신규 빈은 `private class`가 아닌 `@Configuration`/`@Bean`(Spring 보안 설정 관례 유지)
+- [x] 2.2 `SecurityConfiguration.permittedUrls`에서 `/health/**`, `/info/**` 제거 (actuator가 메인 포트에 더 이상 없음). `/login/**`, `/html/**`, `/ws/**`는 유지
+- [x] 2.3 관리 connector가 오버레이에서 도달 가능하도록 `management.server.address`를 localhost로 제한하지 않았는지 확인 (기본값 = 모든 인터페이스 유지)
+
+## 3. back/ — 테스트 및 정적 분석
+
+- [x] 3.1 기존 컨트롤러/통합 테스트 패턴(Testcontainers, `local`/`test` 프로파일)에 따라, `test` 프로파일에서 actuator가 메인 포트에 유지됨을 전제로 기존 `redis-pubsub-health` `WebTestClient /health` 테스트가 그대로 통과하는지 확인 (회귀 없음)
+- [x] 3.2 `prometheus` endpoint가 응답하고 본문에 `jvm_memory_used_bytes`·`http_server_requests` 계열 메트릭이 노출되는지 검증하는 테스트 추가 (기존 통합 테스트 구조 따름, 새 mock 인프라 도입 금지)
+- [x] 3.3 `./gradlew test` 전체 통과
+- [x] 3.4 `./gradlew detekt` 통과
+
+## 4. infra/app — Alloy scrape 경로
+
+- [x] 4.1 `infra/app/compose.yml` `alloy.networks`에 `backend` 추가 (`[observability, backend]`)
+- [x] 4.2 `infra/app/alloy-config.alloy`에 `discovery.docker` + `discovery.relabel` 추가: `com_docker_swarm_service_name == "nomat-back_spring-app"`만 keep, `__meta_docker_container_name` → `instance`, `__address__` → `<ip>:8081`, `metrics_path` → `/prometheus`
+- [x] 4.3 `prometheus.scrape "spring_app"` 추가 → `prometheus.relabel "app_allowlist"` 경유 → `prometheus.remote_write.grafana_cloud`
+- [x] 4.4 `prometheus.relabel "app_allowlist"` 추가: `__name__` keep 화이트리스트(`jvm_*`·`process_*`·`system_*`·`http_server_requests*`·`hikaricp_*`·`logback_events*`·`tomcat_*` 등)로 송신 메트릭 제한
+- [x] 4.5 `compose.yml`의 `alloy_config-2` → `alloy_config-3` (Swarm config 키 증가)
+
+## 5. infra/app — 헬스체크 및 nginx
+
+- [x] 5.1 `infra/app/compose.yml` `spring-app.healthcheck`의 `curl` 대상을 `http://localhost:8081/health`로 변경
+- [x] 5.2 `infra/app/nginx.conf`에 `upstream backend_mgmt { server nomat-back_spring-app:8081; }` 추가
+- [x] 5.3 `nginx.conf`에 `location = /info` → `backend_mgmt/info` reverse proxy만 추가 (`proxy_set_header` 기존 패턴 동일). `/health`·`/prometheus`는 프록시하지 않음 (`/health`는 컨테이너 내부 healthcheck 전용)
+- [x] 5.4 `compose.yml`의 `nginx_conf-4` → `nginx_conf-5` (Swarm config 키 증가)
+
+## 6. 문서
+
+- [x] 6.1 `back/CLAUDE.md` 운영 엔드포인트/observability 섹션에 actuator 관리 포트(dev 8081)·`prometheus` endpoint·Micrometer 메트릭 부기
+- [x] 6.2 `infra/CLAUDE.md`: "Alloy가 `spring-app`을 backend 네트워크에서 replica별 scrape" 추가, 네트워크 격리 문구를 "Alloy 한 방향 부분 개방"으로 갱신, 관리 포트·nginx `/info` 단독 allow-list(`/health`는 컨테이너 내부 healthcheck 전용·`/prometheus`는 Alloy 전용) 명시
+
+## 7. 운영 검증 (배포 후 — 코드 변경 외)
+
+- [ ] 7.1 app 노드 `docker service ls`에서 `spring-app`·`nginx`·`alloy` 정상, 컨테이너 수 변화 없음 확인
+- [ ] 7.2 Alloy 컨테이너에서 `spring-app` replica 2개가 scrape 타깃으로 발견되는지 확인 (Alloy `/metrics` 또는 디버그 UI)
+- [ ] 7.3 Grafana Cloud Explore에서 `jvm_memory_used_bytes{node="app"}` 쿼리 → 두 replica가 서로 다른 `instance` 라벨로 조회되는지 확인
+- [ ] 7.4 공개 `curl https://api.dev.nomat.live/info` → `build.commit`/`build.branch` 정상 반환(버전 확인 통로 보존) 확인
+- [ ] 7.5 공개 `curl https://api.dev.nomat.live/prometheus` 및 `.../health` → 둘 다 도달 불가(404/차단) 확인 (공개 표면에는 `/info`만 노출)
+- [ ] 7.6 컨테이너 내부 healthcheck(`localhost:8081/health`)가 Actuator 헬스 결과(`components.redisPubSub`)를 반환하고 Swarm이 컨테이너를 healthy로 유지하는지 확인 (공개 노출 없이 내부 동작 정상)
+- [ ] 7.7 Grafana Cloud Mimir active series 사용량이 예산(앱 ≈ 1k) 내인지, 히스토그램 `_bucket` 시계열이 생성되지 않았는지 확인

--- a/openspec/changes/replace-elk-with-grafana-cloud/tasks.md
+++ b/openspec/changes/replace-elk-with-grafana-cloud/tasks.md
@@ -111,6 +111,6 @@
 - [x] 10.3 self-hosted Prometheus `prometheus-data` Docker volume도 동일하게 1-2주 후 삭제
 - [x] 10.4 EC2 `.env`에서 `LOGSTASH_URL`, Kibana 관련 환경변수 정리 (운영자 수동)
 - [x] 10.5 GitHub Settings → Secrets에서 `LOGSTASH_URL` 시크릿 삭제 (운영자 수동)
-- [x] 10.6 (후속 change 후보) JVM·Spring Boot 메트릭을 Actuator `prometheus` endpoint로 노출 + Alloy scrape 추가 — 본 변경에서는 노출하지 않음 (Non-Goal). 트래픽 가시성이 더 필요하면 후속 변경
-- [x] 10.7 (후속 change 후보) Tempo 도입 — Alloy에 OTLP receiver 추가 + 백엔드에 OpenTelemetry SDK 적용. 본 변경 범위 외
-- [x] 10.8 (후속 change 후보) `event_publication` 테이블 outbox lag 메트릭을 Mimir에 노출 → Modulith outbox 모니터링 강화
+- [] 10.6 (후속 change 후보) JVM·Spring Boot 메트릭을 Actuator `prometheus` endpoint로 노출 + Alloy scrape 추가 — 본 변경에서는 노출하지 않음 (Non-Goal). 트래픽 가시성이 더 필요하면 후속 변경
+- [] 10.7 (후속 change 후보) Tempo 도입 — Alloy에 OTLP receiver 추가 + 백엔드에 OpenTelemetry SDK 적용. 본 변경 범위 외
+- [] 10.8 (후속 change 후보) `event_publication` 테이블 outbox lag 메트릭을 Mimir에 노출 → Modulith outbox 모니터링 강화


### PR DESCRIPTION
## 요약
dev 프로파일에서 Spring Boot Actuator를 전용 관리 포트(8081)로 분리하고 `micrometer-registry-prometheus`로 `prometheus` endpoint를 활성화해 JVM·Spring(heap/GC/스레드/HTTP/HikariCP 등) 메트릭을 노출한다. Grafana Alloy가 `backend` 네트워크에서 `spring-app` replica별로 scrape해 Grafana Cloud Mimir로 송신하고, 공개 ingress에는 `/info`만 노출(allow-list)하며 시계열 카디널리티는 히스토그램 OFF + Alloy 이름 화이트리스트로 제한한다.

## 배경
직전 변경 `replace-elk-with-grafana-cloud`는 node-exporter 시스템 메트릭만 Mimir로 보냈고 JVM·Spring 앱 메트릭은 Non-Goal로 남겼다(해당 change tasks 10.6). 그 결과 `micrometer-registry-prometheus`가 없어 `prometheus` endpoint가 동작하지 않고, Alloy도 앱을 scrape하지 않아 GC 폭주·스레드 고갈·HikariCP 풀 고갈·엔드포인트 지연이 관측 사각지대였다. 단순 endpoint 한 줄 켜기가 아니라 (a) Alloy↔spring-app 네트워크 격리, (b) actuator의 공개 도메인 노출, (c) Grafana Cloud Free 10k active series 한도라는 세 경계 결정이 필요해 OpenSpec change로 설계를 확정했다.

## 주요 변경
- `back/build.gradle.kts`: `runtimeOnly("io.micrometer:micrometer-registry-prometheus")` 추가 (Spring Boot BOM 버전 관리)
- `back/src/main/resources/application.yml`: exposure에 `prometheus` 추가, 히스토그램 가드 `percentiles-histogram.http.server.requests: false` 명시, **dev 프로파일 한정** `management.server.port: 8081`
- `ManagementSecurityConfiguration` 신규: `EndpointRequest.toAnyEndpoint()` → `permitAll`(csrf off·STATELESS·`@Order(1)`·`@Profile("!test")`) — 관리 포트 무인증 내부 전용 체인
- `SecurityConfiguration.permittedUrls`: actuator가 메인 포트에서 빠지므로 `/health/**`·`/info/**` 제거
- `infra/app/alloy-config.alloy`: `discovery.relabel "spring_app"`(swarm service로 keep, `<ip>:8081` 합성, container명→`instance`, path→`/prometheus`) + `prometheus.scrape "spring_app"` → `prometheus.relabel "app_allowlist"`(`__name__` 화이트리스트) → Mimir
- `infra/app/compose.yml`: alloy를 `backend` 네트워크에 합류, healthcheck를 `localhost:8081/health`로 변경, Swarm config 키 증가(`alloy_config-3`·`nginx_conf-5`)
- `infra/app/nginx.conf`: `upstream backend_mgmt`(:8081) + `location = /info`만 공개 reverse proxy(`/health`·`/prometheus`는 미프록시)
- `back/CLAUDE.md`·`infra/CLAUDE.md`: 관리 포트·prometheus·allow-list·네트워크 부분 개방 문서화
- `openspec/changes/expose-application-metrics/`: proposal·design·specs·tasks 추가, `replace-elk` tasks 10.6~10.8 후속 후보 체크 해제
- 테스트 격리(별도 커밋): `IntegrationTestExecutionListener`가 매 테스트 인스턴스마다 ES 인덱스 문서를 delete-by-query로 초기화(인덱스 drop 대신 문서만 삭제 + refresh로 Nori 세팅 보존)

## 테스트
- [x] `PrometheusEndpointIntegrationTest` 추가 — `/prometheus`가 `jvm_memory_used_bytes`·`http_server_requests`를 노출하고 `http_server_requests_seconds_bucket`(히스토그램)은 미생성임을 검증
- [x] `HealthEndpointIntegrationTest` 등 기존 `/health` 계약 회귀 없음 — test 프로파일은 메인 포트 유지(`TestConfiguration`에 관리 체인 미러링)
- [x] `./gradlew test --rerun-tasks` 전체 통과 (실패 0건, ES 컨테이너 단일 컨텍스트 1개) + `./gradlew detekt` 통과
- [ ] 배포 후 운영 검증(tasks 7.x): Alloy가 replica 2개를 타깃으로 발견, Grafana Cloud에서 `jvm_memory_used_bytes{node="app"}` replica별 `instance` 조회, 공개 `/info` 200·`/prometheus`·`/health` 도달 불가, 컨테이너 내부 `localhost:8081/health` 정상, Mimir active series 예산(앱 ≈ 1k) 내·히스토그램 `_bucket` 미생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)